### PR TITLE
fix: 著者名と出版社名の表記揺れによる重複エンティティ問題を修正

### DIFF
--- a/check_duplicates.py
+++ b/check_duplicates.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Check current duplicate authors and publishers in the database
+"""
+import os
+import sys
+from pathlib import Path
+from neo4j import GraphDatabase
+from dotenv import load_dotenv
+
+# Add scripts directory to path
+scripts_dir = Path(__file__).parent / "scripts" / "data_import"
+sys.path.append(str(scripts_dir))
+
+from name_normalizer import normalize_creator_name, normalize_publisher_name
+
+load_dotenv()
+
+
+def check_author_duplicates():
+    """Check for author duplicates that would be resolved by normalization"""
+    
+    uri = os.getenv('NEO4J_URI', 'bolt://localhost:7687')
+    user = os.getenv('NEO4J_USER', 'neo4j')
+    password = os.getenv('NEO4J_PASSWORD', 'password')
+    
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    
+    try:
+        with driver.session() as session:
+            print("=== Checking Author Duplicates ===")
+            
+            # Get authors that contain "尾田"
+            query = """
+            MATCH (a:Author)
+            WHERE a.name CONTAINS "尾田"
+            RETURN a.name
+            ORDER BY a.name
+            """
+            
+            result = session.run(query)
+            authors = [record['a.name'] for record in result]
+            
+            print(f"Found {len(authors)} authors containing '尾田':")
+            for author in authors:
+                normalized = normalize_creator_name(author)
+                print(f"  '{author}' -> '{normalized}'")
+            
+            # Check how many unique normalized names
+            normalized_authors = list(set(normalize_creator_name(a) for a in authors))
+            print(f"\nAfter normalization: {len(normalized_authors)} unique authors")
+            for norm_author in normalized_authors:
+                print(f"  '{norm_author}'")
+            
+            print(f"Reduction: {len(authors)} -> {len(normalized_authors)} ({len(authors) - len(normalized_authors)} duplicates removed)")
+            
+    finally:
+        driver.close()
+
+
+def check_publisher_duplicates():
+    """Check for publisher duplicates that would be resolved by normalization"""
+    
+    uri = os.getenv('NEO4J_URI', 'bolt://localhost:7687')
+    user = os.getenv('NEO4J_USER', 'neo4j')
+    password = os.getenv('NEO4J_PASSWORD', 'password')
+    
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    
+    try:
+        with driver.session() as session:
+            print("\n=== Checking Publisher Duplicates ===")
+            
+            # Get publishers that contain "集英社"
+            query = """
+            MATCH (p:Publisher)
+            WHERE p.name CONTAINS "集英社"
+            RETURN p.name
+            ORDER BY p.name
+            """
+            
+            result = session.run(query)
+            publishers = [record['p.name'] for record in result]
+            
+            print(f"Found {len(publishers)} publishers containing '集英社':")
+            for publisher in publishers:
+                normalized = normalize_publisher_name(publisher)
+                print(f"  '{publisher}' -> '{normalized}'")
+            
+            # Check how many unique normalized names
+            normalized_publishers = list(set(normalize_publisher_name(p) for p in publishers))
+            print(f"\nAfter normalization: {len(normalized_publishers)} unique publishers")
+            for norm_pub in normalized_publishers:
+                print(f"  '{norm_pub}'")
+            
+            print(f"Reduction: {len(publishers)} -> {len(normalized_publishers)} ({len(publishers) - len(normalized_publishers)} duplicates removed)")
+            
+    finally:
+        driver.close()
+
+
+def check_bracket_patterns():
+    """Check common bracket patterns in author names"""
+    
+    uri = os.getenv('NEO4J_URI', 'bolt://localhost:7687')
+    user = os.getenv('NEO4J_USER', 'neo4j')
+    password = os.getenv('NEO4J_PASSWORD', 'password')
+    
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    
+    try:
+        with driver.session() as session:
+            print("\n=== Checking Bracket Patterns ===")
+            
+            # Find authors with brackets
+            query = """
+            MATCH (a:Author)
+            WHERE a.name CONTAINS "["
+            RETURN a.name
+            ORDER BY a.name
+            LIMIT 20
+            """
+            
+            result = session.run(query)
+            authors = [record['a.name'] for record in result]
+            
+            print(f"Sample authors with brackets (showing first 20):")
+            for author in authors:
+                normalized = normalize_creator_name(author)
+                print(f"  '{author}' -> '{normalized}'")
+    
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    check_author_duplicates()
+    check_publisher_duplicates()
+    check_bracket_patterns()

--- a/infrastructure/external/neo4j_repository.py
+++ b/infrastructure/external/neo4j_repository.py
@@ -2,9 +2,16 @@
 Neo4j database repository for manga graph data
 """
 import os
+import sys
+from pathlib import Path
 from typing import Dict, List, Any, Optional
 from neo4j import GraphDatabase
 import logging
+
+# Add scripts directory to path to import name_normalizer
+scripts_dir = Path(__file__).parent.parent.parent / "scripts" / "data_import"
+sys.path.append(str(scripts_dir))
+from name_normalizer import normalize_creator_name, normalize_publisher_name, generate_normalized_id
 
 logger = logging.getLogger(__name__)
 
@@ -305,14 +312,16 @@ class Neo4jMangaRepository:
             # Add authors as nodes and create edges
             for creator in work['creators']:
                 if creator:
-                    author_id = f"author_{abs(hash(creator))}"
-                    author_node = {
-                        'id': author_id,
-                        'label': creator,
-                        'type': 'author'
-                    }
-                    if author_node not in nodes:
-                        nodes.append(author_node)
+                    normalized_creator = normalize_creator_name(creator)
+                    if normalized_creator:
+                        author_id = generate_normalized_id(normalized_creator, "author")
+                        author_node = {
+                            'id': author_id,
+                            'label': normalized_creator,
+                            'type': 'author'
+                        }
+                        if author_node not in nodes:
+                            nodes.append(author_node)
                     
                     edge = {
                         'from': author_id,
@@ -325,14 +334,16 @@ class Neo4jMangaRepository:
             # Add publishers as nodes and create edges
             for publisher in work['publishers']:
                 if publisher:
-                    publisher_id = f"publisher_{abs(hash(publisher))}"
-                    publisher_node = {
-                        'id': publisher_id,
-                        'label': publisher,
-                        'type': 'publisher'
-                    }
-                    if publisher_node not in nodes:
-                        nodes.append(publisher_node)
+                    normalized_publisher = normalize_publisher_name(publisher)
+                    if normalized_publisher:
+                        publisher_id = generate_normalized_id(normalized_publisher, "publisher")
+                        publisher_node = {
+                            'id': publisher_id,
+                            'label': normalized_publisher,
+                            'type': 'publisher'
+                        }
+                        if publisher_node not in nodes:
+                            nodes.append(publisher_node)
                     
                     edge = {
                         'from': publisher_id,
@@ -359,7 +370,8 @@ class Neo4jMangaRepository:
                     nodes.append(related_node)
                 
                 # Create author relationship edge
-                author_id = f"author_{abs(hash(related['author_name']))}"
+                normalized_author = normalize_creator_name(related['author_name'])
+                author_id = generate_normalized_id(normalized_author, "author")
                 if any(n['id'] == author_id for n in nodes):
                     edge = {
                         'from': author_id,
@@ -388,12 +400,14 @@ class Neo4jMangaRepository:
                     # Add creators
                     for creator in related['creators']:
                         if creator:
-                            author_id = f"author_{abs(hash(creator))}"
-                            author_node = {
-                                'id': author_id,
-                                'label': creator,
-                                'type': 'author'
-                            }
+                            normalized_creator = normalize_creator_name(creator)
+                            if normalized_creator:
+                                author_id = generate_normalized_id(normalized_creator, "author")
+                                author_node = {
+                                    'id': author_id,
+                                    'label': normalized_creator,
+                                    'type': 'author'
+                                }
                             if not any(n['id'] == author_id for n in nodes):
                                 nodes.append(author_node)
                             
@@ -409,12 +423,14 @@ class Neo4jMangaRepository:
                     # Add publishers
                     # Handle single publisher from query result
                     if related.get('publisher_name'):
-                        publisher_id = f"publisher_{abs(hash(related['publisher_name']))}"
-                        publisher_node = {
-                            'id': publisher_id,
-                            'label': related['publisher_name'],
-                            'type': 'publisher'
-                        }
+                        normalized_publisher = normalize_publisher_name(related['publisher_name'])
+                        if normalized_publisher:
+                            publisher_id = generate_normalized_id(normalized_publisher, "publisher")
+                            publisher_node = {
+                                'id': publisher_id,
+                                'label': normalized_publisher,
+                                'type': 'publisher'
+                            }
                         if not any(n['id'] == publisher_id for n in nodes):
                             nodes.append(publisher_node)
                         
@@ -454,12 +470,14 @@ class Neo4jMangaRepository:
                     # Add creators of period-related works
                     for creator in related['creators']:
                         if creator:
-                            author_id = f"author_{abs(hash(creator))}"
-                            author_node = {
-                                'id': author_id,
-                                'label': creator,
-                                'type': 'author'
-                            }
+                            normalized_creator = normalize_creator_name(creator)
+                            if normalized_creator:
+                                author_id = generate_normalized_id(normalized_creator, "author")
+                                author_node = {
+                                    'id': author_id,
+                                    'label': normalized_creator,
+                                    'type': 'author'
+                                }
                             if not any(n['id'] == author_id for n in nodes):
                                 nodes.append(author_node)
                             

--- a/scripts/data_import/migrate_database.py
+++ b/scripts/data_import/migrate_database.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Database migration script to apply name normalization
+"""
+import logging
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+from import_to_neo4j import Neo4jImporter
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).parent.parent.parent / "data" / "mediaarts"
+
+
+def migrate_database():
+    """Migrate database to use normalized names"""
+    logger.info("Starting database migration to apply name normalization")
+    
+    # Neo4j接続情報
+    neo4j_uri = os.getenv('NEO4J_URI', 'bolt://localhost:7687')
+    neo4j_user = os.getenv('NEO4J_USER', 'neo4j')
+    neo4j_password = os.getenv('NEO4J_PASSWORD', 'password')
+    
+    try:
+        importer = Neo4jImporter(neo4j_uri, neo4j_user, neo4j_password)
+        
+        # Get current database stats before migration
+        logger.info("Getting database statistics before migration...")
+        old_stats = importer.get_statistics()
+        logger.info("Current statistics:")
+        for key, value in old_stats.items():
+            logger.info(f"  {key}: {value:,}")
+        
+        # Ask for confirmation before clearing
+        response = input("\n⚠️  This will CLEAR ALL DATA and re-import with normalized names.\nAre you sure? Type 'YES' to continue: ")
+        if response != 'YES':
+            logger.info("Migration cancelled")
+            return
+        
+        # Clear database
+        logger.info("Clearing database...")
+        importer.clear_database()
+        
+        # Recreate constraints
+        logger.info("Creating constraints...")
+        importer.create_constraints()
+        
+        # Re-import data with normalization
+        logger.info("Re-importing data with name normalization...")
+        
+        # Import manga books
+        book_file = DATA_DIR / "metadata101_json" / "metadata101.json"
+        if book_file.exists():
+            logger.info(f"Importing manga books from {book_file}")
+            importer.import_manga_books(book_file)
+        else:
+            logger.warning(f"Book file not found: {book_file}")
+        
+        # Import manga series  
+        series_file = DATA_DIR / "metadata104_json" / "metadata104.json"
+        if series_file.exists():
+            logger.info(f"Importing manga series from {series_file}")
+            importer.import_manga_series(series_file)
+        else:
+            logger.warning(f"Series file not found: {series_file}")
+        
+        # Create additional relationships
+        logger.info("Creating additional relationships...")
+        importer.create_additional_relationships()
+        
+        # Get new statistics
+        logger.info("Getting database statistics after migration...")
+        new_stats = importer.get_statistics()
+        
+        # Display comparison
+        logger.info("\n=== Migration Results ===")
+        logger.info("Before -> After:")
+        for key in old_stats:
+            old_val = old_stats.get(key, 0)
+            new_val = new_stats.get(key, 0)
+            change = new_val - old_val
+            logger.info(f"  {key}: {old_val:,} -> {new_val:,} ({change:+,})")
+        
+        logger.info("\n✅ Migration completed successfully!")
+        logger.info("The database now uses normalized creator and publisher names.")
+        
+    except Exception as e:
+        logger.error(f"Migration failed: {e}")
+        raise
+    finally:
+        if 'importer' in locals():
+            importer.close()
+
+
+def check_normalization_impact():
+    """Check how many duplicates would be resolved by normalization"""
+    logger.info("Analyzing normalization impact...")
+    
+    # This would analyze the JSON files to see how many duplicates exist
+    # For now, we'll just log a message
+    logger.info("Use this function to analyze the impact before migration")
+    
+    # TODO: Implement analysis of JSON files to count duplicates
+
+
+if __name__ == "__main__":
+    import sys
+    
+    if len(sys.argv) > 1 and sys.argv[1] == "--analyze":
+        check_normalization_impact()
+    else:
+        migrate_database()

--- a/scripts/data_import/name_normalizer.py
+++ b/scripts/data_import/name_normalizer.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Name normalization utilities for manga creators and publishers
+"""
+import re
+from typing import Optional
+
+
+def normalize_creator_name(name: str) -> str:
+    """
+    Normalize creator name by removing role prefixes and brackets
+    
+    Examples:
+        "[著]尾田栄一郎" -> "尾田栄一郎"
+        "[[著]]尾田栄一郎" -> "尾田栄一郎"
+        "[原作]尾田栄一郎" -> "尾田栄一郎"
+        "[作画]Boichi" -> "Boichi"
+    
+    Args:
+        name: Original creator name
+        
+    Returns:
+        Normalized creator name
+    """
+    if not name or not isinstance(name, str):
+        return ""
+    
+    normalized = name.strip()
+    
+    # Remove role prefixes in brackets: [著], [原作], [作画], [[著]], etc.
+    # Pattern matches single or double brackets with any content
+    normalized = re.sub(r'\[+[^\]]*\]+', '', normalized)
+    
+    # Remove any remaining whitespace
+    normalized = normalized.strip()
+    
+    return normalized
+
+
+def normalize_publisher_name(name: str) -> str:
+    """
+    Normalize publisher name by removing reading annotations
+    
+    Examples:
+        "集英社　∥　シュウエイシャ" -> "集英社"
+        "講談社　∥　コウダンシャ" -> "講談社"
+        "小学館" -> "小学館"
+    
+    Args:
+        name: Original publisher name
+        
+    Returns:
+        Normalized publisher name
+    """
+    if not name or not isinstance(name, str):
+        return ""
+    
+    normalized = name.strip()
+    
+    # Remove reading annotation part (everything after ∥ symbol)
+    normalized = re.sub(r'　*∥.*$', '', normalized)
+    
+    # Remove any trailing whitespace
+    normalized = normalized.strip()
+    
+    return normalized
+
+
+def generate_normalized_id(name: str, entity_type: str) -> str:
+    """
+    Generate normalized ID for entities
+    
+    Args:
+        name: Normalized name
+        entity_type: Type of entity ('author' or 'publisher')
+        
+    Returns:
+        Normalized ID string
+    """
+    if not name:
+        return ""
+    
+    return f"{entity_type}_{abs(hash(name))}"
+
+
+def test_normalizations():
+    """Test function to verify normalization rules"""
+    print("=== Creator Name Normalization Tests ===")
+    
+    creator_tests = [
+        "[著]尾田栄一郎",
+        "[[著]]尾田栄一郎", 
+        "[原作]尾田栄一郎",
+        "[作画]Boichi",
+        "[デザイン]バナナグローブスタジオ",
+        "[監修]Fischer's",
+        "尾田栄一郎",  # Already normalized
+        "　[編]ジャンプ・コミック出版編集部　",  # With spaces
+    ]
+    
+    for test_name in creator_tests:
+        normalized = normalize_creator_name(test_name)
+        print(f"'{test_name}' -> '{normalized}'")
+    
+    print("\n=== Publisher Name Normalization Tests ===")
+    
+    publisher_tests = [
+        "集英社　∥　シュウエイシャ",
+        "講談社　∥　コウダンシャ",
+        "小学館",
+        "集英社",  # Already normalized
+        "　小学館　∥　ショウガクカン　",  # With spaces
+    ]
+    
+    for test_name in publisher_tests:
+        normalized = normalize_publisher_name(test_name)
+        print(f"'{test_name}' -> '{normalized}'")
+    
+    print("\n=== ID Generation Tests ===")
+    
+    # Test that different representations produce same ID
+    creator_variations = [
+        "[著]尾田栄一郎",
+        "[[著]]尾田栄一郎",
+        "[原作]尾田栄一郎",
+    ]
+    
+    creator_ids = []
+    for variation in creator_variations:
+        normalized = normalize_creator_name(variation)
+        id_val = generate_normalized_id(normalized, "author")
+        creator_ids.append(id_val)
+        print(f"'{variation}' -> normalized: '{normalized}' -> ID: '{id_val}'")
+    
+    print(f"All creator IDs same: {len(set(creator_ids)) == 1}")
+    
+    publisher_variations = [
+        "集英社　∥　シュウエイシャ",
+        "集英社",
+    ]
+    
+    publisher_ids = []
+    for variation in publisher_variations:
+        normalized = normalize_publisher_name(variation)
+        id_val = generate_normalized_id(normalized, "publisher")
+        publisher_ids.append(id_val)
+        print(f"'{variation}' -> normalized: '{normalized}' -> ID: '{id_val}'")
+    
+    print(f"All publisher IDs same: {len(set(publisher_ids)) == 1}")
+
+
+if __name__ == "__main__":
+    test_normalizations()

--- a/test_normalization.py
+++ b/test_normalization.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Test normalization functionality with sample data
+"""
+import sys
+from pathlib import Path
+
+# Add scripts directory to path
+scripts_dir = Path(__file__).parent / "scripts" / "data_import"
+sys.path.append(str(scripts_dir))
+
+from name_normalizer import normalize_creator_name, normalize_publisher_name, generate_normalized_id
+
+
+def test_one_piece_problem():
+    """Test the specific One Piece problem mentioned by the user"""
+    print("=== Testing One Piece Problem Cases ===")
+    
+    # Test creator normalization (the main issue)
+    creator_variants = [
+        "[著]尾田栄一郎",
+        "[[著]]尾田栄一郎", 
+        "[原作]尾田栄一郎",
+        "尾田栄一郎"  # Expected normalized form
+    ]
+    
+    print("Creator name normalization:")
+    normalized_creators = []
+    creator_ids = []
+    
+    for variant in creator_variants:
+        normalized = normalize_creator_name(variant)
+        creator_id = generate_normalized_id(normalized, "author")
+        normalized_creators.append(normalized)
+        creator_ids.append(creator_id)
+        print(f"  '{variant}' -> '{normalized}' (ID: {creator_id})")
+    
+    # Check if all variants produce the same result
+    all_same_name = len(set(normalized_creators)) == 1
+    all_same_id = len(set(creator_ids)) == 1
+    
+    print(f"\n✅ All creator names normalize to same value: {all_same_name}")
+    print(f"✅ All creator IDs are identical: {all_same_id}")
+    
+    # Test publisher normalization
+    publisher_variants = [
+        "集英社　∥　シュウエイシャ",
+        "集英社"  # Expected normalized form
+    ]
+    
+    print("\nPublisher name normalization:")
+    normalized_publishers = []
+    publisher_ids = []
+    
+    for variant in publisher_variants:
+        normalized = normalize_publisher_name(variant)
+        publisher_id = generate_normalized_id(normalized, "publisher")
+        normalized_publishers.append(normalized)
+        publisher_ids.append(publisher_id)
+        print(f"  '{variant}' -> '{normalized}' (ID: {publisher_id})")
+    
+    # Check if all variants produce the same result
+    all_same_pub_name = len(set(normalized_publishers)) == 1
+    all_same_pub_id = len(set(publisher_ids)) == 1
+    
+    print(f"\n✅ All publisher names normalize to same value: {all_same_pub_name}")
+    print(f"✅ All publisher IDs are identical: {all_same_pub_id}")
+    
+    # Overall result
+    success = all_same_name and all_same_id and all_same_pub_name and all_same_pub_id
+    print(f"\n{'🎉 NORMALIZATION TEST PASSED' if success else '❌ NORMALIZATION TEST FAILED'}")
+    
+    return success
+
+
+def test_edge_cases():
+    """Test edge cases for normalization"""
+    print("\n=== Testing Edge Cases ===")
+    
+    edge_cases = [
+        ("", "Empty string"),
+        ("   ", "Whitespace only"),
+        ("[編集]編集部", "Editorial role"),
+        ("[作画・原作]複数の役割", "Multiple roles"),
+        ("　[構成・編集]　得能久子　", "Spaces around brackets"),
+        ("出版社名　∥　読み仮名　∥　追加情報", "Multiple separators"),
+    ]
+    
+    print("Edge case testing:")
+    for test_input, description in edge_cases:
+        creator_normalized = normalize_creator_name(test_input)
+        publisher_normalized = normalize_publisher_name(test_input)
+        print(f"  {description}")
+        print(f"    Input: '{test_input}'")
+        print(f"    Creator: '{creator_normalized}'")
+        print(f"    Publisher: '{publisher_normalized}'")
+        print()
+
+
+def test_id_consistency():
+    """Test that ID generation is consistent across runs"""
+    print("=== Testing ID Consistency ===")
+    
+    test_name = "尾田栄一郎"
+    
+    # Generate IDs multiple times
+    ids = []
+    for i in range(5):
+        author_id = generate_normalized_id(test_name, "author")
+        ids.append(author_id)
+    
+    all_same = len(set(ids)) == 1
+    print(f"Generated IDs for '{test_name}': {ids[0]}")
+    print(f"✅ ID generation is consistent: {all_same}")
+    
+    return all_same
+
+
+if __name__ == "__main__":
+    print("🧪 Testing Name Normalization Implementation\n")
+    
+    # Run all tests
+    test1_passed = test_one_piece_problem()
+    test_edge_cases()
+    test2_passed = test_id_consistency()
+    
+    # Summary
+    print("\n" + "="*50)
+    if test1_passed and test2_passed:
+        print("🎉 ALL TESTS PASSED!")
+        print("The normalization implementation should resolve the One Piece duplicate issue.")
+    else:
+        print("❌ SOME TESTS FAILED!")
+        print("Please review the implementation before proceeding.")

--- a/test_normalization_import.py
+++ b/test_normalization_import.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Test the normalization implementation with sample data
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, List, Any
+import os
+from dotenv import load_dotenv
+
+# Add scripts directory to path
+scripts_dir = Path(__file__).parent / "scripts" / "data_import"
+sys.path.append(str(scripts_dir))
+
+from import_to_neo4j import Neo4jImporter
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def test_normalization_with_sample_data():
+    """Test normalization with the sample data"""
+    logger.info("Testing normalization with sample data")
+    
+    # Neo4j connection info
+    neo4j_uri = os.getenv('NEO4J_URI', 'bolt://localhost:7687')
+    neo4j_user = os.getenv('NEO4J_USER', 'neo4j') 
+    neo4j_password = os.getenv('NEO4J_PASSWORD', 'password')
+    
+    try:
+        importer = Neo4jImporter(neo4j_uri, neo4j_user, neo4j_password)
+        
+        # Load test data
+        test_file = Path(__file__).parent / "test_data_sample.json"
+        with open(test_file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        
+        items = data.get('@graph', [])
+        logger.info(f"Loaded {len(items)} test items")
+        
+        # Create a test namespace in database
+        logger.info("Importing test data...")
+        
+        # Import the test batch
+        importer._import_book_batch(items)
+        
+        # Query the results to verify normalization
+        logger.info("Verifying normalization results...")
+        
+        with importer.driver.session() as session:
+            # Check authors
+            author_query = """
+            MATCH (a:Author)
+            WHERE a.name CONTAINS "尾田"
+            RETURN a.id, a.name, a.original_name
+            ORDER BY a.name
+            """
+            
+            logger.info("Authors found:")
+            author_result = session.run(author_query)
+            author_count = 0
+            for record in author_result:
+                author_count += 1
+                logger.info(f"  ID: {record['a.id']}")
+                logger.info(f"  Normalized: {record['a.name']}")
+                logger.info(f"  Original: {record['a.original_name']}")
+                logger.info("  ---")
+            
+            # Check publishers
+            publisher_query = """
+            MATCH (p:Publisher)
+            WHERE p.name CONTAINS "集英社"
+            RETURN p.id, p.name, p.original_name
+            ORDER BY p.name
+            """
+            
+            logger.info("Publishers found:")
+            publisher_result = session.run(publisher_query)
+            publisher_count = 0
+            for record in publisher_result:
+                publisher_count += 1
+                logger.info(f"  ID: {record['p.id']}")
+                logger.info(f"  Normalized: {record['p.name']}")
+                logger.info(f"  Original: {record['p.original_name']}")
+                logger.info("  ---")
+            
+            # Check works
+            work_query = """
+            MATCH (w:Work)
+            WHERE w.title CONTAINS "ONE PIECE"
+            OPTIONAL MATCH (a:Author)-[:CREATED]->(w)
+            OPTIONAL MATCH (p:Publisher)-[:PUBLISHED]->(w)
+            RETURN w.title, collect(a.name) as authors, collect(p.name) as publishers
+            ORDER BY w.title
+            """
+            
+            logger.info("Works found:")
+            work_result = session.run(work_query)
+            work_count = 0
+            for record in work_result:
+                work_count += 1
+                logger.info(f"  Title: {record['w.title']}")
+                logger.info(f"  Authors: {record['authors']}")
+                logger.info(f"  Publishers: {record['publishers']}")
+                logger.info("  ---")
+        
+        # Evaluation
+        logger.info("\n=== Test Results ===")
+        logger.info(f"Unique authors found: {author_count}")
+        logger.info(f"Unique publishers found: {publisher_count}")
+        logger.info(f"Works found: {work_count}")
+        
+        success = author_count == 1 and publisher_count == 1 and work_count == 3
+        
+        if success:
+            logger.info("🎉 NORMALIZATION TEST PASSED!")
+            logger.info("All variants of '尾田栄一郎' were normalized to a single author")
+            logger.info("All variants of '集英社' were normalized to a single publisher")
+        else:
+            logger.error("❌ NORMALIZATION TEST FAILED!")
+            logger.error("Expected 1 author, 1 publisher, 3 works")
+        
+        return success
+        
+    except Exception as e:
+        logger.error(f"Test failed: {e}")
+        return False
+    finally:
+        if 'importer' in locals():
+            importer.close()
+
+
+if __name__ == "__main__":
+    success = test_normalization_with_sample_data()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- 著者名と出版社名の表記揺れにより同一人物・組織が別エンティティとして扱われる問題を修正
- 正規化処理により "[著]尾田栄一郎" と "[原作]尾田栄一郎" などが同一IDに統合される
- "集英社　∥　シュウエイシャ" と "集英社" も同一IDに統合される

## Changes
- 名前正規化ユーティリティ (`scripts/data_import/name_normalizer.py`) を実装
- データインポート処理に正規化ロジックを統合
- Neo4jリポジトリの検索処理にも正規化を適用
- 元の表記は `original_name` フィールドで保持
- データベースマイグレーションスクリプトを追加

## Test Results
現在のデータベース分析結果:
- **著者重複削減**: 7個 → 4個 (3個の重複削除)
- **出版社重複削減**: 30個 → 16個 (14個の重複削除)

## Test plan
- [x] 正規化関数の単体テスト
- [x] 実データベースでの重複確認テスト
- [x] ID生成の一貫性テスト
- [ ] フルマイグレーション実行（本番適用時）

🤖 Generated with [Claude Code](https://claude.ai/code)