### PR TITLE
feat: Add bulk cover retrieval API endpoint

### DIFF
--- a/domain/services/cover_image_service.py
+++ b/domain/services/cover_image_service.py
@@ -2,11 +2,12 @@
 """
 Book cover image service for retrieving cover images from various sources
 """
-import requests
 import logging
-from typing import Optional, Dict, Any, List
-from urllib.parse import urlencode
 import time
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
+
+import requests
 
 from .cover_cache_service import get_cache_service
 
@@ -15,61 +16,61 @@ logger = logging.getLogger(__name__)
 
 class CoverImageService:
     """Service for retrieving book cover images from multiple sources"""
-    
+
     def __init__(self):
         self.google_books_base_url = "https://www.googleapis.com/books/v1/volumes"
         self.openbd_base_url = "https://api.openbd.jp/v1/get"
         self.request_delay = 0.1  # Rate limiting delay
         self.cache_service = get_cache_service()
-        
+
     def get_cover_image_url(self, isbn: str, title: str = None) -> Optional[str]:
         """
         Get cover image URL for a book by ISBN
-        
+
         Args:
             isbn: ISBN of the book
             title: Optional title for fallback search
-            
+
         Returns:
             Cover image URL if found, None otherwise
         """
         if not isbn:
             logger.warning("No ISBN provided for cover image lookup")
             return None
-        
+
         # Check cache first
         cached_url = self.cache_service.get_cached_cover(isbn, title)
         if cached_url is not None:
             logger.debug(f"Using cached cover for ISBN {isbn}")
             return cached_url
-            
+
         # Try Google Books API first (most reliable for covers)
         cover_url = self._get_cover_from_google_books(isbn, title)
         if cover_url:
             # Cache the successful result
             self.cache_service.cache_cover(isbn, cover_url, title)
             return cover_url
-            
+
         # Try openBD as fallback
         cover_url = self._get_cover_from_openbd(isbn)
         if cover_url:
             # Cache the successful result
             self.cache_service.cache_cover(isbn, cover_url, title)
             return cover_url
-        
+
         # Cache the negative result to avoid repeated API calls
         self.cache_service.cache_cover(isbn, None, title)
         logger.info(f"No cover image found for ISBN: {isbn}")
         return None
-    
+
     def _get_cover_from_google_books(self, isbn: str, title: str = None) -> Optional[str]:
         """
         Get cover image from Google Books API
-        
+
         Args:
             isbn: ISBN to search for
             title: Optional title for enhanced search
-            
+
         Returns:
             Cover image URL if found
         """
@@ -77,138 +78,138 @@ class CoverImageService:
             # First try ISBN search
             query = f"isbn:{isbn}"
             url = f"{self.google_books_base_url}?q={query}"
-            
+
             logger.debug(f"Searching Google Books with ISBN: {isbn}")
             response = requests.get(url, timeout=10)
-            
+
             if response.status_code == 200:
                 data = response.json()
-                items = data.get('items', [])
-                
+                items = data.get("items", [])
+
                 if items:
                     # Get the first item's image links
-                    volume_info = items[0].get('volumeInfo', {})
-                    image_links = volume_info.get('imageLinks', {})
-                    
+                    volume_info = items[0].get("volumeInfo", {})
+                    image_links = volume_info.get("imageLinks", {})
+
                     if image_links:
                         # Prefer larger images
-                        for size in ['large', 'medium', 'thumbnail', 'smallThumbnail']:
+                        for size in ["large", "medium", "thumbnail", "smallThumbnail"]:
                             if size in image_links:
                                 cover_url = image_links[size]
                                 # Convert to HTTPS if needed
-                                if cover_url.startswith('http://'):
-                                    cover_url = cover_url.replace('http://', 'https://')
-                                
+                                if cover_url.startswith("http://"):
+                                    cover_url = cover_url.replace("http://", "https://")
+
                                 logger.info(f"Found cover via Google Books (ISBN): {cover_url}")
                                 return cover_url
-                
+
                 # If ISBN search failed and we have a title, try title search
                 if title and not items:
                     time.sleep(self.request_delay)
                     title_query = f"intitle:{title}"
                     title_url = f"{self.google_books_base_url}?q={title_query}"
-                    
+
                     logger.debug(f"Searching Google Books with title: {title}")
                     title_response = requests.get(title_url, timeout=10)
-                    
+
                     if title_response.status_code == 200:
                         title_data = title_response.json()
-                        title_items = title_data.get('items', [])
-                        
+                        title_items = title_data.get("items", [])
+
                         if title_items:
                             # Look for best match (exact title)
                             for item in title_items[:3]:  # Check first 3 results
-                                volume_info = item.get('volumeInfo', {})
-                                item_title = volume_info.get('title', '').lower()
-                                
+                                volume_info = item.get("volumeInfo", {})
+                                item_title = volume_info.get("title", "").lower()
+
                                 if title.lower() in item_title or item_title in title.lower():
-                                    image_links = volume_info.get('imageLinks', {})
+                                    image_links = volume_info.get("imageLinks", {})
                                     if image_links:
-                                        for size in ['large', 'medium', 'thumbnail', 'smallThumbnail']:
+                                        for size in ["large", "medium", "thumbnail", "smallThumbnail"]:
                                             if size in image_links:
                                                 cover_url = image_links[size]
-                                                if cover_url.startswith('http://'):
-                                                    cover_url = cover_url.replace('http://', 'https://')
-                                                
+                                                if cover_url.startswith("http://"):
+                                                    cover_url = cover_url.replace("http://", "https://")
+
                                                 logger.info(f"Found cover via Google Books (title): {cover_url}")
                                                 return cover_url
             else:
                 logger.warning(f"Google Books API error: {response.status_code}")
-                
+
         except Exception as e:
             logger.error(f"Error fetching cover from Google Books: {e}")
-        
+
         return None
-    
+
     def _get_cover_from_openbd(self, isbn: str) -> Optional[str]:
         """
         Get cover image from openBD API
-        
+
         Args:
             isbn: ISBN to search for
-            
+
         Returns:
             Cover image URL if found
         """
         try:
             url = f"{self.openbd_base_url}?isbn={isbn}"
-            
+
             logger.debug(f"Searching openBD with ISBN: {isbn}")
             response = requests.get(url, timeout=10)
-            
+
             if response.status_code == 200:
                 data = response.json()
-                
+
                 if data and len(data) > 0 and data[0]:
                     book_data = data[0]
-                    summary = book_data.get('summary', {})
-                    cover_url = summary.get('cover', '')
-                    
+                    summary = book_data.get("summary", {})
+                    cover_url = summary.get("cover", "")
+
                     if cover_url:
                         logger.info(f"Found cover via openBD: {cover_url}")
                         return cover_url
             else:
                 logger.warning(f"openBD API error: {response.status_code}")
-                
+
         except Exception as e:
             logger.error(f"Error fetching cover from openBD: {e}")
-        
+
         return None
-    
+
     def get_placeholder_image_url(self, genre: str = None, publisher: str = None) -> str:
         """
         Get placeholder image URL based on genre or publisher
-        
+
         Args:
             genre: Genre of the work
             publisher: Publisher of the work
-            
+
         Returns:
             Placeholder image URL
         """
         # Generate placeholder based on genre/publisher
-        if genre and 'マンガ' in genre:
+        if genre and "マンガ" in genre:
             return "/static/images/placeholders/manga-cover.png"
         elif publisher:
             # Publisher-specific placeholder
             publisher_lower = publisher.lower()
-            if '集英社' in publisher:
+            if "集英社" in publisher:
                 return "/static/images/placeholders/shueisha-cover.png"
-            elif '講談社' in publisher:
+            elif "講談社" in publisher:
                 return "/static/images/placeholders/kodansha-cover.png"
-            elif '小学館' in publisher:
+            elif "小学館" in publisher:
                 return "/static/images/placeholders/shogakukan-cover.png"
-        
+
         # Default placeholder
         return "/static/images/placeholders/default-cover.png"
-    
+
     def validate_cover_url(self, url: str) -> bool:
         """
         Validate that a cover URL is accessible
-        
+
         Args:
             url: URL to validate
-            
+
         Returns:
             True if URL is accessible, False otherwise
         """
@@ -217,43 +218,37 @@ class CoverImageService:
             return response.status_code == 200
         except Exception:
             return False
-    
-    def get_cover_with_fallback(self, isbn: str, title: str = None, 
-                               genre: str = None, publisher: str = None) -> Dict[str, Any]:
+
+    def get_cover_with_fallback(
+        self, isbn: str, title: str = None, genre: str = None, publisher: str = None
+    ) -> Dict[str, Any]:
         """
         Get cover image with fallback to placeholder
-        
+
         Args:
             isbn: ISBN of the book
             title: Title of the book
             genre: Genre for placeholder selection
             publisher: Publisher for placeholder selection
-            
+
         Returns:
             Dictionary with cover_url and source information
         """
         # Try to get actual cover
         cover_url = self.get_cover_image_url(isbn, title)
-        
+
         if cover_url and self.validate_cover_url(cover_url):
-            return {
-                'cover_url': cover_url,
-                'source': 'api',
-                'has_real_cover': True
-            }
-        
+            return {"cover_url": cover_url, "source": "api", "has_real_cover": True}
+
         # Fallback to placeholder
         placeholder_url = self.get_placeholder_image_url(genre, publisher)
-        
-        return {
-            'cover_url': placeholder_url,
-            'source': 'placeholder',
-            'has_real_cover': False
-        }
+
+        return {"cover_url": placeholder_url, "source": "placeholder", "has_real_cover": False}
 
 
 # Singleton instance
 _cover_service_instance = None
+
 
 def get_cover_service() -> CoverImageService:
     """Get singleton instance of CoverImageService"""

--- a/domain/services/image_fetch_service.py
+++ b/domain/services/image_fetch_service.py
@@ -1,0 +1,148 @@
+import asyncio
+import aiohttp
+from typing import List, Dict, Any, Optional
+import logging
+from io import BytesIO
+
+logger = logging.getLogger(__name__)
+
+
+class ImageFetchService:
+    """Service for fetching images from URLs asynchronously"""
+
+    def __init__(self, timeout: int = 30, max_concurrent: int = 10):
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self.max_concurrent = max_concurrent
+        self.session: Optional[aiohttp.ClientSession] = None
+
+    async def __aenter__(self):
+        """Async context manager entry"""
+        self.session = aiohttp.ClientSession(timeout=self.timeout)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit"""
+        if self.session:
+            await self.session.close()
+
+    async def _fetch_single_image(self, work_id: str, cover_url: str) -> Dict[str, Any]:
+        """Fetch a single image from URL
+        
+        Args:
+            work_id: Work identifier
+            cover_url: URL to fetch image from
+            
+        Returns:
+            Dict containing result data
+        """
+        try:
+            if not self.session:
+                raise RuntimeError("Session not initialized. Use async context manager.")
+
+            async with self.session.get(cover_url) as response:
+                if response.status == 200:
+                    content_type = response.headers.get('Content-Type', 'image/jpeg')
+                    image_data = await response.read()
+                    
+                    return {
+                        'work_id': work_id,
+                        'image_data': image_data,
+                        'content_type': content_type,
+                        'file_size': len(image_data),
+                        'success': True,
+                        'error': None
+                    }
+                else:
+                    logger.warning(f"Failed to fetch image for work_id {work_id}: HTTP {response.status}")
+                    return {
+                        'work_id': work_id,
+                        'image_data': None,
+                        'content_type': None,
+                        'file_size': 0,
+                        'success': False,
+                        'error': f"HTTP {response.status}"
+                    }
+
+        except asyncio.TimeoutError:
+            logger.error(f"Timeout fetching image for work_id {work_id}")
+            return {
+                'work_id': work_id,
+                'image_data': None,
+                'content_type': None,
+                'file_size': 0,
+                'success': False,
+                'error': "Timeout"
+            }
+        except Exception as e:
+            logger.error(f"Error fetching image for work_id {work_id}: {str(e)}")
+            return {
+                'work_id': work_id,
+                'image_data': None,
+                'content_type': None,
+                'file_size': 0,
+                'success': False,
+                'error': str(e)
+            }
+
+    async def fetch_images(self, requests: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+        """Fetch multiple images concurrently
+        
+        Args:
+            requests: List of dicts with 'work_id' and 'cover_url' keys
+            
+        Returns:
+            List of result dicts
+        """
+        if not requests:
+            return []
+
+        # Create semaphore to limit concurrent requests
+        semaphore = asyncio.Semaphore(self.max_concurrent)
+
+        async def fetch_with_semaphore(work_id: str, cover_url: str):
+            async with semaphore:
+                return await self._fetch_single_image(work_id, cover_url)
+
+        # Create tasks for all requests
+        tasks = [
+            fetch_with_semaphore(req['work_id'], req['cover_url'])
+            for req in requests
+        ]
+
+        # Execute all tasks concurrently
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Handle any exceptions that occurred
+        processed_results = []
+        for i, result in enumerate(results):
+            if isinstance(result, Exception):
+                logger.error(f"Exception in task {i}: {str(result)}")
+                processed_results.append({
+                    'work_id': requests[i]['work_id'],
+                    'image_data': None,
+                    'content_type': None,
+                    'file_size': 0,
+                    'success': False,
+                    'error': str(result)
+                })
+            else:
+                processed_results.append(result)
+
+        return processed_results
+
+    async def fetch_single_image(self, work_id: str, cover_url: str) -> Dict[str, Any]:
+        """Fetch a single image (convenience method)
+        
+        Args:
+            work_id: Work identifier
+            cover_url: URL to fetch image from
+            
+        Returns:
+            Result dict
+        """
+        return await self._fetch_single_image(work_id, cover_url)
+
+
+def get_image_fetch_service() -> ImageFetchService:
+    """Factory function to get ImageFetchService instance"""
+    return ImageFetchService()

--- a/domain/services/neo4j_media_arts_service.py
+++ b/domain/services/neo4j_media_arts_service.py
@@ -5,8 +5,8 @@ Neo4j-based media arts service for faster graph data retrieval
 import logging
 from typing import Any, Dict, List, Optional
 
-from infrastructure.external.neo4j_repository import Neo4jMangaRepository
 from domain.services.mock_neo4j_service import MockNeo4jService
+from infrastructure.external.neo4j_repository import Neo4jMangaRepository
 
 logger = logging.getLogger(__name__)
 
@@ -16,10 +16,10 @@ class Neo4jMediaArtsService:
 
     def __init__(self, neo4j_repository: Optional[Neo4jMangaRepository] = None):
         import os
-        
+
         # Force mock mode if USE_MOCK_NEO4J is set or Neo4j connection fails
         use_mock_env = os.getenv("USE_MOCK_NEO4J", "false").lower() == "true"
-        
+
         if use_mock_env:
             logger.info("USE_MOCK_NEO4J is set, using mock service")
             self.neo4j_repository = MockNeo4jService()
@@ -30,7 +30,7 @@ class Neo4jMediaArtsService:
                 self.use_mock = False
                 # Test connection by getting stats
                 stats = self.neo4j_repository.get_database_statistics()
-                if not stats or stats.get('work_count', 0) == 0:
+                if not stats or stats.get("work_count", 0) == 0:
                     logger.warning("Neo4j database appears to be empty, switching to mock service")
                     self.neo4j_repository = MockNeo4jService()
                     self.use_mock = True
@@ -78,7 +78,7 @@ class Neo4jMediaArtsService:
         if not self.neo4j_repository:
             logger.warning("Neo4j repository is not available")
             return {"nodes": [], "edges": []}
-            
+
         try:
             result = self.neo4j_repository.search_manga_data_with_related(search_term, limit, include_related)
 
@@ -164,7 +164,7 @@ class Neo4jMediaArtsService:
         except Exception as e:
             logger.error(f"Error getting database statistics: {e}")
             return {}
-    
+
     def get_work_by_id(self, work_id: str) -> Optional[Dict[str, Any]]:
         """Get work details by ID"""
         try:
@@ -172,7 +172,7 @@ class Neo4jMediaArtsService:
         except Exception as e:
             logger.error(f"Error getting work by ID {work_id}: {e}")
             return None
-    
+
     def update_work_cover_image(self, work_id: str, cover_url: str) -> bool:
         """Update work cover image URL"""
         try:
@@ -180,7 +180,7 @@ class Neo4jMediaArtsService:
         except Exception as e:
             logger.error(f"Error updating cover image for work {work_id}: {e}")
             return False
-    
+
     def get_works_needing_covers(self, limit: int = 100) -> List[Dict[str, Any]]:
         """Get works that have ISBN but no cover image"""
         try:

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from presentation.api import manga_router, media_arts_router, neo4j_router, cover_router
+from presentation.api import manga_router, media_arts_router, neo4j_router, cover_router, image_router
 
 load_dotenv()
 
@@ -21,6 +21,7 @@ app.include_router(manga_router)
 app.include_router(media_arts_router)
 app.include_router(neo4j_router)
 app.include_router(cover_router)
+app.include_router(image_router)
 
 
 @app.get("/")

--- a/presentation/api/__init__.py
+++ b/presentation/api/__init__.py
@@ -1,3 +1,3 @@
-from .manga_api import router as manga_router, media_arts_router, neo4j_router, cover_router
+from .manga_api import router as manga_router, media_arts_router, neo4j_router, cover_router, image_router
 
-__all__ = ["manga_router", "media_arts_router", "neo4j_router", "cover_router"]
+__all__ = ["manga_router", "media_arts_router", "neo4j_router", "cover_router", "image_router"]

--- a/presentation/schemas/__init__.py
+++ b/presentation/schemas/__init__.py
@@ -1,9 +1,13 @@
 from .manga_schemas import (
     NodeData, EdgeData, SearchRequest, GraphResponse,
-    AuthorResponse, WorkResponse, MagazineResponse
+    AuthorResponse, WorkResponse, MagazineResponse,
+    ImageFetchRequest, ImageFetchResponse,
+    BulkImageFetchRequest, BulkImageFetchResponse
 )
 
 __all__ = [
     "NodeData", "EdgeData", "SearchRequest", "GraphResponse",
-    "AuthorResponse", "WorkResponse", "MagazineResponse"
+    "AuthorResponse", "WorkResponse", "MagazineResponse",
+    "ImageFetchRequest", "ImageFetchResponse",
+    "BulkImageFetchRequest", "BulkImageFetchResponse"
 ]

--- a/presentation/schemas/__init__.py
+++ b/presentation/schemas/__init__.py
@@ -2,12 +2,14 @@ from .manga_schemas import (
     NodeData, EdgeData, SearchRequest, GraphResponse,
     AuthorResponse, WorkResponse, MagazineResponse,
     ImageFetchRequest, ImageFetchResponse,
-    BulkImageFetchRequest, BulkImageFetchResponse
+    BulkImageFetchRequest, BulkImageFetchResponse,
+    CoverResponse, BulkCoverRequest, BulkCoverResponse
 )
 
 __all__ = [
     "NodeData", "EdgeData", "SearchRequest", "GraphResponse",
     "AuthorResponse", "WorkResponse", "MagazineResponse",
     "ImageFetchRequest", "ImageFetchResponse",
-    "BulkImageFetchRequest", "BulkImageFetchResponse"
+    "BulkImageFetchRequest", "BulkImageFetchResponse",
+    "CoverResponse", "BulkCoverRequest", "BulkCoverResponse"
 ]

--- a/presentation/schemas/manga_schemas.py
+++ b/presentation/schemas/manga_schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
+import base64
 
 
 class NodeData(BaseModel):
@@ -53,3 +54,40 @@ class MagazineResponse(BaseModel):
     name: str
     publisher: str
     established_date: Optional[str] = None
+
+
+class ImageFetchRequest(BaseModel):
+    work_id: str
+    cover_url: str
+
+
+class ImageFetchResponse(BaseModel):
+    work_id: str
+    image_data: str  # Base64 encoded image data
+    content_type: str
+    file_size: int
+    success: bool
+    error: Optional[str] = None
+
+    @classmethod
+    def from_bytes(cls, work_id: str, image_data: bytes, content_type: str, success: bool, error: Optional[str] = None):
+        """Create response from bytes data"""
+        return cls(
+            work_id=work_id,
+            image_data=base64.b64encode(image_data).decode('utf-8') if image_data else '',
+            content_type=content_type or '',
+            file_size=len(image_data) if image_data else 0,
+            success=success,
+            error=error
+        )
+
+
+class BulkImageFetchRequest(BaseModel):
+    requests: List[ImageFetchRequest]
+
+
+class BulkImageFetchResponse(BaseModel):
+    results: List[ImageFetchResponse]
+    total_processed: int
+    success_count: int
+    error_count: int

--- a/presentation/schemas/manga_schemas.py
+++ b/presentation/schemas/manga_schemas.py
@@ -91,3 +91,22 @@ class BulkImageFetchResponse(BaseModel):
     total_processed: int
     success_count: int
     error_count: int
+
+
+class CoverResponse(BaseModel):
+    work_id: str
+    cover_url: Optional[str] = None
+    source: str  # 'database', 'api', 'placeholder'
+    has_real_cover: bool
+    error: Optional[str] = None
+
+
+class BulkCoverRequest(BaseModel):
+    work_ids: List[str]
+
+
+class BulkCoverResponse(BaseModel):
+    results: List[CoverResponse]
+    total_processed: int
+    success_count: int
+    error_count: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ aiofiles==23.2.1
 pytest==7.4.3
 pytest-asyncio==0.21.1
 sparqlwrapper==2.0.0
+aiohttp==3.9.1


### PR DESCRIPTION
## Summary
- Add new API endpoint `/api/v1/covers/bulk` for retrieving multiple work cover URLs in a single request
- Uses the same logic as existing individual cover retrieval API for efficient batch processing
- Includes comprehensive error handling and response statistics

## Changes
- Add `BulkCoverRequest`, `BulkCoverResponse`, and `CoverResponse` Pydantic schemas
- Implement `get_bulk_covers` endpoint with proper error handling
- Add individual cover processing with error isolation
- Include success/failure statistics in response structure

## Test plan
- [x] Verify new API endpoint functionality
- [x] Confirm proper registration in OpenAPI documentation
- [x] Test error cases (non-existent work_ids)
- [x] Validate response structure and statistics

🤖 Generated with [Claude Code](https://claude.ai/code)