### PR TITLE
Add data import script and tests for Neo4j integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ python import_full_data.py
 # 依存関係のインストール
 pip install -r requirements.txt
 
+# 日本語形態素解析の辞書をダウンロード
+python -m unidic download
+
 # 開発サーバー起動
 uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   neo4j:
-    image: neo4j:latest
+    image: neo4j:community
     container_name: manga-neo4j
     ports:
       - "7474:7474"

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,31 @@
+@scripts/data_import/import_to_neo4j_v4.py
+を以下のルールに従って漫画のグラフDBを作成してください。
+
+# データについて
+- data/mediaarts/以下にメディア芸術データベースのデータが格納されています。
+
+## 使用するファイル
+- `@data/mediaarts/metadata104.json`: 漫画単行本シリーズデータ
+- 
+
+# nodeについて
+必要なnodeは以下の4つです。
+1. work（漫画）
+2. creator（原作者）
+3. magazine（雑誌）
+4. publisher（発行社）
+
+## idの取得方法
+`@data/mediaarts/*.json`にそれぞれのデータのidが"@id"としてありますのでそれを使ってください。（例: "@id": "https://mediaarts-db.artmuseums.go.jp/id/C61770"）
+
+## nodeの取得の仕方
+1. 
+
+# edgeについて
+## 必要なedge
+必要なedgeは以下の3つです。
+1. work -> creator
+2. work -> magazine
+3. magazine -> publisher
+
+## edgeの取得の仕方

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest-asyncio==0.21.1
 sparqlwrapper==2.0.0
 aiohttp==3.9.1
 tqdm==4.67.1
+kanjiconv==0.1.2

--- a/scripts/data_import/check_import_progress.py
+++ b/scripts/data_import/check_import_progress.py
@@ -1,0 +1,156 @@
+import os
+import subprocess
+import time
+from datetime import datetime
+
+from neo4j import GraphDatabase
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+
+class ImportProgressMonitor:
+    def __init__(self):
+        self.driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
+
+    def close(self):
+        self.driver.close()
+
+    def get_database_status(self):
+        """データベースの現在の状況を取得"""
+        with self.driver.session() as session:
+            status = {}
+
+            # ノード数をカウント
+            for label in ["Work", "Author", "Publisher", "Magazine"]:
+                result = session.run(f"MATCH (n:{label}) RETURN count(n) AS count")
+                status[label] = result.single()["count"]
+
+            # リレーションシップ数をカウント
+            relationships = {}
+            for rel_type in ["CREATED_BY", "PUBLISHED_IN", "PUBLISHED_BY"]:
+                result = session.run(f"MATCH ()-[r:{rel_type}]->() RETURN count(r) AS count")
+                relationships[rel_type] = result.single()["count"]
+
+            status["Relationships"] = relationships
+            return status
+
+    def check_import_process(self):
+        """インポートプロセスが実行中かチェック"""
+        try:
+            result = subprocess.run(["pgrep", "-f", "import_to_neo4j_v3.py"], capture_output=True, text=True)
+            if result.returncode == 0 and result.stdout.strip():
+                return True, result.stdout.strip().split("\n")
+            return False, []
+        except Exception:
+            return False, []
+
+    def estimate_progress_stage(self, status):
+        """現在の進行段階を推定"""
+        total_nodes = sum(status[label] for label in ["Work", "Author", "Publisher", "Magazine"])
+        total_relationships = sum(status["Relationships"].values())
+
+        if total_nodes == 0:
+            return "初期化中またはデータ分類中"
+        elif status["Publisher"] > 0 and status["Author"] == 0:
+            return "出版社ノード作成中"
+        elif status["Author"] > 0 and status["Magazine"] == 0:
+            return "著者ノード作成中"
+        elif status["Magazine"] > 0 and status["Work"] == 0:
+            return "雑誌ノード作成中"
+        elif status["Work"] > 0 and total_relationships == 0:
+            return "作品ノード作成中"
+        elif total_relationships > 0:
+            return "リレーションシップ作成中"
+        else:
+            return "完了またはエラー"
+
+    def display_progress(self):
+        """進行状況を表示"""
+        print(f"\n{'='*60}")
+        print(f"インポート進行状況チェック - {datetime.now().strftime('%H:%M:%S')}")
+        print(f"{'='*60}")
+
+        # プロセス状況チェック
+        is_running, pids = self.check_import_process()
+        if is_running:
+            print(f"✅ インポートプロセス実行中 (PID: {', '.join(pids)})")
+        else:
+            print("❌ インポートプロセスが見つかりません")
+
+        print()
+
+        # データベース状況
+        try:
+            status = self.get_database_status()
+            stage = self.estimate_progress_stage(status)
+
+            print(f"📊 現在の段階: {stage}")
+            print()
+
+            print("ノード数:")
+            for label, count in status.items():
+                if label != "Relationships":
+                    print(f"  {label}: {count:,}")
+
+            print()
+            print("リレーションシップ数:")
+            for rel_type, count in status["Relationships"].items():
+                print(f"  {rel_type}: {count:,}")
+
+            # 推定完了度
+            total_expected = {"Publisher": 8291, "Author": 27574, "Magazine": 214105, "Work": 146619}
+
+            print()
+            print("推定進捗:")
+            for label, expected in total_expected.items():
+                current = status.get(label, 0)
+                if expected > 0:
+                    progress = min(100, (current / expected) * 100)
+                    bar_length = 20
+                    filled_length = int(bar_length * progress / 100)
+                    bar = "█" * filled_length + "░" * (bar_length - filled_length)
+                    print(f"  {label:10}: |{bar}| {progress:5.1f}% ({current:,}/{expected:,})")
+
+        except Exception as e:
+            print(f"❌ データベース接続エラー: {e}")
+
+    def monitor_continuously(self, interval=30):
+        """継続的に監視"""
+        print("Neo4j インポート進行状況監視を開始...")
+        print("Ctrl+C で終了")
+
+        try:
+            while True:
+                self.display_progress()
+                time.sleep(interval)
+        except KeyboardInterrupt:
+            print("\n\n監視を終了します...")
+            self.close()
+
+
+def main():
+    monitor = ImportProgressMonitor()
+
+    try:
+        # 引数で実行モード選択
+        import sys
+
+        if len(sys.argv) > 1 and sys.argv[1] == "--continuous":
+            # 継続監視モード
+            interval = int(sys.argv[2]) if len(sys.argv) > 2 else 30
+            monitor.monitor_continuously(interval)
+        else:
+            # 1回だけチェック
+            monitor.display_progress()
+
+    except Exception as e:
+        print(f"エラー: {e}")
+    finally:
+        monitor.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_import/check_neo4j_status.py
+++ b/scripts/data_import/check_neo4j_status.py
@@ -1,0 +1,74 @@
+import os
+
+from neo4j import GraphDatabase
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+print(f"Connecting to Neo4j at {neo4j_uri}...")
+
+
+class MangaGraphDB:
+    def __init__(self, uri, user, password):
+        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+
+    def close(self):
+        self.driver.close()
+
+    def get_status(self):
+        """データベースの状態を確認"""
+        with self.driver.session() as session:
+            # ノード数をカウント
+            print("\n=== Node Counts ===")
+            for label in ["Work", "Author", "Publisher", "Magazine"]:
+                result = session.run(f"MATCH (n:{label}) RETURN count(n) AS count")
+                count = result.single()["count"]
+                print(f"{label}: {count:,}")
+
+            # リレーションシップ数をカウント
+            print("\n=== Relationship Counts ===")
+            relationships = ["CREATED_BY", "PUBLISHED_IN", "PUBLISHED_BY"]
+            for rel in relationships:
+                result = session.run(f"MATCH ()-[r:{rel}]->() RETURN count(r) AS count")
+                count = result.single()["count"]
+                print(f"{rel}: {count:,}")
+
+            # サンプルデータを表示
+            print("\n=== Sample Data ===")
+
+            # 作品のサンプル
+            print("\nSample Works (first 5):")
+            result = session.run("MATCH (w:Work) RETURN w.title AS title LIMIT 5")
+            for record in result:
+                print(f"  - {record['title']}")
+
+            # 著者のサンプル
+            print("\nSample Authors (first 5):")
+            result = session.run("MATCH (a:Author) RETURN a.id AS id LIMIT 5")
+            for record in result:
+                print(f"  - {record['id']}")
+
+            # 出版社のサンプル
+            print("\nSample Publishers (first 5):")
+            result = session.run("MATCH (p:Publisher) RETURN p.name AS name LIMIT 5")
+            for record in result:
+                print(f"  - {record['name']}")
+
+            # 制約の確認
+            print("\n=== Constraints ===")
+            result = session.run("SHOW CONSTRAINTS")
+            for record in result:
+                print(f"  - {record['name']}: {record['labelsOrTypes']} {record['properties']}")
+
+
+try:
+    db = MangaGraphDB(neo4j_uri, neo4j_user, neo4j_password)
+    db.get_status()
+    db.close()
+
+except Exception as e:
+    print(f"Error: {e}")
+    print("\nMake sure Neo4j is running and the credentials are correct.")
+    print("You can set environment variables: NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD")

--- a/scripts/data_import/check_one_piece.py
+++ b/scripts/data_import/check_one_piece.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+ONE PIECEのデータを詳細に確認
+"""
+
+import os
+
+from neo4j import GraphDatabase
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
+
+
+def check_one_piece_details():
+    """ONE PIECEの詳細確認"""
+    print("=== ONE PIECE Details ===")
+
+    with driver.session() as session:
+        # 1. IDで直接検索
+        print("\n1. Direct search by ID:")
+        query = """
+        MATCH (w:Work {id: 'https://mediaarts-db.artmuseums.go.jp/id/M1037106'})
+        RETURN w
+        """
+        result = session.run(query)
+        record = result.single()
+        if record:
+            work = record["w"]
+            print(f"Found: {work}")
+            for key, value in work.items():
+                print(f"  {key}: {value}")
+        else:
+            print("Not found by ID")
+
+        # 2. タイトルで検索（完全一致）
+        print("\n2. Search by exact title:")
+        query = """
+        MATCH (w:Work {title: 'ONE PIECE'})
+        RETURN w
+        """
+        result = session.run(query)
+        for record in result:
+            work = record["w"]
+            print(f"Found: ID={work['id']}, Title={work['title']}")
+
+        # 3. リレーションシップの確認
+        print("\n3. Check relationships for ONE PIECE:")
+        query = """
+        MATCH (w:Work)
+        WHERE w.title = 'ONE PIECE'
+        OPTIONAL MATCH (w)-[r1:CREATED_BY]->(a:Author)
+        OPTIONAL MATCH (w)-[r2:PUBLISHED_IN]->(m:Magazine)
+        RETURN w.id AS work_id, w.title AS title, 
+               collect(DISTINCT a) AS authors,
+               collect(DISTINCT m) AS magazines,
+               count(r1) AS author_count,
+               count(r2) AS magazine_count
+        """
+        result = session.run(query)
+        for record in result:
+            print(f"Work ID: {record['work_id']}")
+            print(f"Title: {record['title']}")
+            print(f"Author relationships: {record['author_count']}")
+            print(f"Magazine relationships: {record['magazine_count']}")
+            print(f"Authors: {[a['name'] if 'name' in a else a['id'] for a in record['authors']]}")
+            print(f"Magazines: {[m['title'] if 'title' in m else m['id'] for m in record['magazines']]}")
+
+        # 4. データベース内のONE PIECE関連作品を全て検索
+        print("\n4. All ONE PIECE related works:")
+        query = """
+        MATCH (w:Work)
+        WHERE toLower(w.title) CONTAINS 'one piece' OR toLower(w.title) CONTAINS 'ワンピース'
+        RETURN w.id, w.title, w.is_series, w.total_volumes
+        ORDER BY w.title
+        LIMIT 20
+        """
+        result = session.run(query)
+        count = 0
+        for record in result:
+            print(
+                f"  - {record['w.title']} (ID: {record['w.id']}, Series: {record['w.is_series']}, Volumes: {record['w.total_volumes']})"
+            )
+            count += 1
+        print(f"Total found: {count}")
+
+
+def check_author_format():
+    """著者名のフォーマット確認"""
+    print("\n\n=== Author Name Format Check ===")
+
+    with driver.session() as session:
+        query = """
+        MATCH (a:Author)
+        WHERE a.name CONTAINS '[著]'
+        RETURN a.id, a.name
+        LIMIT 10
+        """
+        result = session.run(query)
+        for record in result:
+            print(f"  ID: {record['a.id']}, Name: {record['a.name']}")
+
+
+if __name__ == "__main__":
+    check_one_piece_details()
+    check_author_format()
+    driver.close()

--- a/scripts/data_import/debug_neo4j_search.py
+++ b/scripts/data_import/debug_neo4j_search.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Neo4j検索のデバッグスクリプト
+"""
+
+import os
+from neo4j import GraphDatabase
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
+
+def test_connection():
+    """接続テスト"""
+    print("=== Neo4j Connection Test ===")
+    try:
+        with driver.session() as session:
+            result = session.run("RETURN 1 AS test")
+            record = result.single()
+            print(f"✓ Connection successful: {record['test']}")
+            return True
+    except Exception as e:
+        print(f"✗ Connection failed: {e}")
+        return False
+
+def check_node_counts():
+    """ノード数の確認"""
+    print("\n=== Node Counts ===")
+    with driver.session() as session:
+        for label in ["Work", "Author", "Publisher", "Magazine"]:
+            result = session.run(f"MATCH (n:{label}) RETURN count(n) AS count")
+            count = result.single()["count"]
+            print(f"{label}: {count:,}")
+
+def check_relationship_counts():
+    """リレーションシップ数の確認"""
+    print("\n=== Relationship Counts ===")
+    with driver.session() as session:
+        for rel_type in ["CREATED_BY", "PUBLISHED_IN", "PUBLISHED_BY"]:
+            result = session.run(f"MATCH ()-[r:{rel_type}]->() RETURN count(r) AS count")
+            count = result.single()["count"]
+            print(f"{rel_type}: {count:,}")
+
+def search_one_piece():
+    """ONE PIECEの検索テスト"""
+    print("\n=== Searching for 'ONE PIECE' ===")
+    
+    search_term = "ONE PIECE"
+    
+    with driver.session() as session:
+        # 1. 基本的な検索
+        print("\n1. Basic search (exact match):")
+        query = """
+        MATCH (w:Work)
+        WHERE w.title = $search_term
+        RETURN w.id, w.title
+        LIMIT 5
+        """
+        result = session.run(query, search_term=search_term)
+        for record in result:
+            print(f"  - ID: {record['w.id']}, Title: {record['w.title']}")
+        
+        # 2. 大文字小文字を無視した部分一致検索
+        print("\n2. Case-insensitive contains search:")
+        query = """
+        MATCH (w:Work)
+        WHERE toLower(w.title) CONTAINS toLower($search_term)
+        RETURN w.id, w.title
+        LIMIT 5
+        """
+        result = session.run(query, search_term=search_term)
+        count = 0
+        for record in result:
+            print(f"  - ID: {record['w.id']}, Title: {record['w.title']}")
+            count += 1
+        print(f"  Total found: {count}")
+        
+        # 3. ワンピースのカタカナ検索
+        print("\n3. Searching for 'ワンピース':")
+        query = """
+        MATCH (w:Work)
+        WHERE toLower(w.title) CONTAINS toLower($search_term)
+        RETURN w.id, w.title
+        LIMIT 5
+        """
+        result = session.run(query, search_term="ワンピース")
+        count = 0
+        for record in result:
+            print(f"  - ID: {record['w.id']}, Title: {record['w.title']}")
+            count += 1
+        print(f"  Total found: {count}")
+        
+        # 4. リレーションシップ付きの検索
+        print("\n4. Search with relationships:")
+        query = """
+        MATCH (w:Work)
+        WHERE toLower(w.title) CONTAINS toLower($search_term)
+        OPTIONAL MATCH (w)-[:CREATED_BY]->(a:Author)
+        OPTIONAL MATCH (w)-[:PUBLISHED_IN]->(m:Magazine)
+        RETURN w.id, w.title, collect(DISTINCT a.name) AS authors, collect(DISTINCT m.title) AS magazines
+        LIMIT 5
+        """
+        result = session.run(query, search_term="ワンピース")
+        for record in result:
+            print(f"  - ID: {record['w.id']}")
+            print(f"    Title: {record['w.title']}")
+            print(f"    Authors: {record['authors']}")
+            print(f"    Magazines: {record['magazines']}")
+
+def check_sample_works():
+    """サンプル作品の確認"""
+    print("\n=== Sample Works ===")
+    with driver.session() as session:
+        query = """
+        MATCH (w:Work)
+        RETURN w.id, w.title
+        ORDER BY w.title
+        LIMIT 10
+        """
+        result = session.run(query)
+        for record in result:
+            print(f"  - ID: {record['w.id']}, Title: {record['w.title']}")
+
+def check_work_schema():
+    """Workノードのスキーマ確認"""
+    print("\n=== Work Node Schema ===")
+    with driver.session() as session:
+        query = """
+        MATCH (w:Work)
+        WITH w LIMIT 1
+        RETURN keys(w) AS properties
+        """
+        result = session.run(query)
+        record = result.single()
+        if record:
+            print(f"Properties: {record['properties']}")
+        else:
+            print("No Work nodes found!")
+
+# メイン実行
+if __name__ == "__main__":
+    if test_connection():
+        check_node_counts()
+        check_relationship_counts()
+        check_work_schema()
+        check_sample_works()
+        search_one_piece()
+    
+    driver.close()

--- a/scripts/data_import/debug_relationships.py
+++ b/scripts/data_import/debug_relationships.py
@@ -1,0 +1,99 @@
+import os
+
+from neo4j import GraphDatabase
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+
+def debug_naruto_relationships():
+    """NARUTOに関連するリレーションシップをデバッグ"""
+    driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
+
+    with driver.session() as session:
+        print("=== NARUTO関連のWork検索 ===")
+
+        # NARUTO関連のWorkを検索
+        result = session.run(
+            """
+            MATCH (w:Work)
+            WHERE w.title CONTAINS 'NARUTO' OR w.title CONTAINS 'Naruto'
+            RETURN w.id, w.title
+            LIMIT 5
+        """
+        )
+
+        works = list(result)
+        print(f"Found {len(works)} NARUTO works:")
+        for work in works:
+            print(f"  ID: {work['w.id']}, Title: {work['w.title']}")
+
+        if works:
+            # 最初のNARUTO作品のリレーションシップを確認
+            first_work_id = works[0]["w.id"]
+            print(f"\n=== '{first_work_id}'のリレーションシップ ===")
+
+            # 作品から著者への関係
+            result = session.run(
+                """
+                MATCH (w:Work {id: $work_id})-[r:CREATED_BY]->(a:Author)
+                RETURN r, a.id, a.name
+                LIMIT 5
+            """,
+                work_id=first_work_id,
+            )
+
+            authors = list(result)
+            print(f"Authors connected to this work: {len(authors)}")
+            for author in authors:
+                print(f"  Author ID: {author['a.id']}, Name: {author['a.name']}")
+
+            # 作品から雑誌への関係
+            result = session.run(
+                """
+                MATCH (w:Work {id: $work_id})-[r:PUBLISHED_IN]->(m:Magazine)
+                RETURN r, m.id, m.title
+                LIMIT 5
+            """,
+                work_id=first_work_id,
+            )
+
+            magazines = list(result)
+            print(f"Magazines connected to this work: {len(magazines)}")
+            for magazine in magazines:
+                print(f"  Magazine ID: {magazine['m.id']}, Title: {magazine['m.title']}")
+
+        print("\n=== 全体のリレーションシップ統計 ===")
+
+        # 全体の統計
+        result = session.run("MATCH ()-[r:CREATED_BY]->() RETURN count(r) AS count")
+        created_by_count = result.single()["count"]
+        print(f"Total CREATED_BY relationships: {created_by_count}")
+
+        result = session.run("MATCH ()-[r:PUBLISHED_IN]->() RETURN count(r) AS count")
+        published_in_count = result.single()["count"]
+        print(f"Total PUBLISHED_IN relationships: {published_in_count}")
+
+        result = session.run("MATCH ()-[r:PUBLISHED_BY]->() RETURN count(r) AS count")
+        published_by_count = result.single()["count"]
+        print(f"Total PUBLISHED_BY relationships: {published_by_count}")
+
+        print("\n=== サンプルのCREATED_BY関係 ===")
+        result = session.run(
+            """
+            MATCH (w:Work)-[r:CREATED_BY]->(a:Author)
+            RETURN w.title, a.name, a.id
+            LIMIT 5
+        """
+        )
+
+        for record in result:
+            print(f"Work: {record['w.title']} -> Author: {record['a.name']} (ID: {record['a.id']})")
+
+    driver.close()
+
+
+if __name__ == "__main__":
+    debug_naruto_relationships()

--- a/scripts/data_import/debug_search_method.py
+++ b/scripts/data_import/debug_search_method.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+search_manga_data_with_relatedメソッドのデバッグ
+"""
+
+import os
+import sys
+from pathlib import Path
+import logging
+
+# パスを追加
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+from infrastructure.external.neo4j_repository import Neo4jMangaRepository
+from domain.services.neo4j_media_arts_service import Neo4jMediaArtsService
+
+# ロギング設定
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+def test_repository_directly():
+    """リポジトリを直接テスト"""
+    print("=== Testing Neo4jMangaRepository directly ===\n")
+    
+    try:
+        repo = Neo4jMangaRepository()
+        
+        # 1. search_manga_worksのテスト
+        print("1. Testing search_manga_works('ONE PIECE'):")
+        works = repo.search_manga_works("ONE PIECE", limit=5)
+        print(f"Found {len(works)} works")
+        for work in works:
+            print(f"  - {work['title']} (ID: {work['work_id']})")
+        
+        # 2. search_manga_data_with_relatedのテスト
+        print("\n2. Testing search_manga_data_with_related('ONE PIECE'):")
+        result = repo.search_manga_data_with_related("ONE PIECE", limit=5, include_related=False)
+        print(f"Nodes: {len(result['nodes'])}")
+        print(f"Edges: {len(result['edges'])}")
+        
+        if result['nodes']:
+            print("\nFirst few nodes:")
+            for node in result['nodes'][:3]:
+                print(f"  - {node['type']}: {node['label']} (ID: {node['id']})")
+        
+        if result['edges']:
+            print("\nFirst few edges:")
+            for edge in result['edges'][:3]:
+                print(f"  - {edge['type']}: {edge['source']} -> {edge['target']}")
+        
+        repo.close()
+        
+    except Exception as e:
+        print(f"Error in repository test: {e}")
+        import traceback
+        traceback.print_exc()
+
+def test_service_directly():
+    """サービスを直接テスト"""
+    print("\n\n=== Testing Neo4jMediaArtsService directly ===\n")
+    
+    try:
+        service = Neo4jMediaArtsService()
+        
+        print("1. Testing search_manga_data_with_related('ONE PIECE'):")
+        result = service.search_manga_data_with_related("ONE PIECE", limit=5, include_related=False)
+        print(f"Nodes: {len(result['nodes'])}")
+        print(f"Edges: {len(result['edges'])}")
+        
+        if result['nodes']:
+            print("\nFirst few nodes:")
+            for node in result['nodes'][:3]:
+                print(f"  - {node['type']}: {node['label']} (ID: {node['id']})")
+        
+        service.close()
+        
+    except Exception as e:
+        print(f"Error in service test: {e}")
+        import traceback
+        traceback.print_exc()
+
+def test_api_flow():
+    """API呼び出しフローを模擬"""
+    print("\n\n=== Simulating API call flow ===\n")
+    
+    from presentation.api.manga_api import get_neo4j_media_arts_service
+    
+    try:
+        # 依存性注入を通じてサービスを取得
+        service = get_neo4j_media_arts_service()
+        print(f"Service type: {type(service)}")
+        print(f"Repository type: {type(service.neo4j_repository)}")
+        print(f"Use mock: {service.use_mock}")
+        
+        # 検索実行
+        result = service.search_manga_data_with_related("ONE PIECE", limit=5, include_related=False)
+        print(f"\nSearch result:")
+        print(f"Nodes: {len(result['nodes'])}")
+        print(f"Edges: {len(result['edges'])}")
+        
+    except Exception as e:
+        print(f"Error in API flow test: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    test_repository_directly()
+    test_service_directly()
+    test_api_flow()

--- a/scripts/data_import/import_to_neo4j_continue.py
+++ b/scripts/data_import/import_to_neo4j_continue.py
@@ -1,0 +1,270 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+from neo4j import GraphDatabase
+
+
+# データ読み込み関数
+def load_json_ld(filename):
+    """JSON-LD形式のファイルを読み込む"""
+    with open(filename, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("@graph", [])
+
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+
+class MangaGraphDB:
+    def __init__(self, uri, user, password):
+        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+
+    def close(self):
+        self.driver.close()
+
+    def get_current_status(self):
+        """現在のインポート状況を確認"""
+        with self.driver.session() as session:
+            status = {}
+            for label in ["Work", "Author", "Publisher", "Magazine"]:
+                result = session.run(f"MATCH (n:{label}) RETURN count(n) AS count")
+                status[label] = result.single()["count"]
+            return status
+
+    def create_work_node(self, work_name, work_data):
+        """マンガ作品（シリーズ）ノードを作成"""
+        with self.driver.session() as session:
+            query = """
+            MERGE (w:Work {id: $work_id})
+            SET w.title = $title,
+                w.total_volumes = $total_volumes,
+                w.first_published = $first_published,
+                w.last_published = $last_published
+            """
+
+            # 総巻数と最初・最後の出版日を計算
+            total_volumes = len(work_data["books"])
+            dates = [
+                book.get("schema:datePublished", "") for book in work_data["books"] if book.get("schema:datePublished")
+            ]
+            first_published = min(dates) if dates else ""
+            last_published = max(dates) if dates else ""
+
+            session.run(
+                query,
+                {
+                    "work_id": work_name,
+                    "title": work_name,
+                    "total_volumes": total_volumes,
+                    "first_published": first_published,
+                    "last_published": last_published,
+                },
+            )
+
+    def create_work_author_relationship(self, work_name, author_id):
+        """作品と著者の関係を作成"""
+        with self.driver.session() as session:
+            query = """
+            MATCH (w:Work {id: $work_id})
+            MATCH (a:Author {id: $author_id})
+            MERGE (w)-[:CREATED_BY]->(a)
+            """
+            session.run(query, {"work_id": work_name, "author_id": author_id})
+
+    def create_magazine_node(self, magazine):
+        """雑誌ノードを作成（継続用）"""
+        with self.driver.session() as session:
+            # 既に存在するかチェック
+            check_query = "MATCH (m:Magazine {id: $magazine_id}) RETURN m"
+            result = session.run(check_query, {"magazine_id": magazine.get("@id", "")})
+            if result.single() is not None:
+                return False  # 既に存在
+
+            query = """
+            MERGE (m:Magazine {id: $magazine_id})
+            SET m.title = $title,
+                m.publisher = $publisher,
+                m.genre = $genre
+            """
+
+            # タイトルの取得
+            title = magazine.get("schema:name", "")
+            if isinstance(title, list):
+                title = title[0] if title else ""
+
+            session.run(
+                query,
+                {
+                    "magazine_id": magazine.get("@id", ""),
+                    "title": title,
+                    "publisher": magazine.get("schema:publisher", ""),
+                    "genre": magazine.get("schema:genre", ""),
+                },
+            )
+            return True
+
+    def create_magazine_publisher_relationship(self, magazine_id, publisher_name):
+        """雑誌と出版社の関係を作成"""
+        with self.driver.session() as session:
+            query = """
+            MATCH (m:Magazine {id: $magazine_id})
+            MATCH (p:Publisher {id: $publisher_id})
+            MERGE (m)-[:PUBLISHED_BY]->(p)
+            """
+            session.run(query, {"magazine_id": magazine_id, "publisher_id": publisher_name})
+
+
+# メイン処理
+print("=== Continuing Neo4j Import ===")
+
+try:
+    db = MangaGraphDB(neo4j_uri, neo4j_user, neo4j_password)
+
+    # 現在の状況を確認
+    print("\nCurrent status:")
+    status = db.get_current_status()
+    for label, count in status.items():
+        print(f"  {label}: {count:,}")
+
+    # データを読み込む
+    print("\nLoading data...")
+    script_dir = Path(__file__).parent
+    data_dir = script_dir.parent.parent / "data" / "mediaarts"
+    json_files = list(data_dir.glob("*.json"))
+
+    all_data = []
+    for file_path in json_files:
+        print(f"Loading {file_path.name}...")
+        try:
+            data = load_json_ld(str(file_path))
+            all_data.extend(data)
+        except Exception as e:
+            print(f"Error loading {file_path}: {e}")
+
+    print(f"\nTotal items loaded: {len(all_data)}")
+
+    # データの分類
+    manga_books = []
+    magazines = []
+
+    for item in all_data:
+        item_type = item.get("@type", "")
+        genre = item.get("schema:genre", "")
+
+        if item_type == "class:MangaBook" and genre == "マンガ単行本":
+            manga_books.append(item)
+        elif genre in ["マンガ雑誌", "雑誌", "雑誌全号まとめ"] or "Magazine" in item_type:
+            magazines.append(item)
+
+    # 残りの雑誌をインポート
+    if status["Magazine"] < len(magazines):
+        print(f"\nContinuing magazine import from {status['Magazine']:,}/{len(magazines):,}...")
+
+        processed = 0
+        skipped = 0
+        for i, magazine in enumerate(magazines):
+            if i % 1000 == 0:
+                print(f"  Progress: {i:,}/{len(magazines):,} (processed: {processed}, skipped: {skipped})")
+
+            try:
+                if db.create_magazine_node(magazine):
+                    processed += 1
+
+                    # 雑誌と出版社の関係を作成
+                    publisher = magazine.get("schema:publisher", "")
+                    if publisher:
+                        if isinstance(publisher, list):
+                            publisher = publisher[0] if publisher else ""
+                        if publisher:
+                            db.create_magazine_publisher_relationship(magazine.get("@id", ""), publisher)
+                else:
+                    skipped += 1
+            except Exception as e:
+                print(f"  Error processing magazine {i}: {e}")
+
+        print(f"  Magazine import completed. Processed: {processed}, Skipped: {skipped}")
+
+    # 作品データの作成
+    if status["Work"] == 0:
+        print("\nCreating work nodes...")
+
+        # マンガ作品（シリーズ）の抽出
+        work_dict = {}
+        for book in manga_books:
+            # 作品名を取得（巻数を除いたタイトル）
+            full_name = book.get("schema:name", "")
+
+            # nameフィールドの処理
+            if isinstance(full_name, list):
+                for name in full_name:
+                    if isinstance(name, str):
+                        full_name = name
+                        break
+                    elif isinstance(name, dict) and "@value" in name:
+                        full_name = name["@value"]
+                        break
+                else:
+                    continue
+            elif isinstance(full_name, dict):
+                if "@value" in full_name:
+                    full_name = full_name["@value"]
+                else:
+                    continue
+            elif not isinstance(full_name, str):
+                continue
+
+            # 巻数を除いた作品名を取得
+            work_name = full_name
+            volume_num = book.get("schema:volumeNumber", "")
+            if volume_num and isinstance(work_name, str):
+                work_name = work_name.replace(f" {volume_num}", "").strip()
+
+            if work_name and isinstance(work_name, str):
+                if work_name not in work_dict:
+                    work_dict[work_name] = {"name": work_name, "books": [], "creators": set()}
+
+                work_dict[work_name]["books"].append(book)
+
+                # 著者情報を追加
+                creator = book.get("dcterms:creator", {})
+                if isinstance(creator, dict) and "@id" in creator:
+                    work_dict[work_name]["creators"].add(creator["@id"])
+
+        print(f"Found {len(work_dict)} works to import")
+
+        # バッチ処理
+        BATCH_SIZE = 100
+        work_items = list(work_dict.items())
+
+        for i in range(0, len(work_items), BATCH_SIZE):
+            batch = work_items[i : i + BATCH_SIZE]
+            try:
+                for work_name, work_data in batch:
+                    # 作品ノードを作成
+                    db.create_work_node(work_name, work_data)
+
+                    # 作品と著者の関係を作成
+                    for creator_id in work_data["creators"]:
+                        db.create_work_author_relationship(work_name, creator_id)
+
+                print(f"  Processed {min(i + BATCH_SIZE, len(work_items))}/{len(work_items)} works")
+            except Exception as e:
+                print(f"  Error processing works batch {i//BATCH_SIZE + 1}: {e}")
+
+    # 最終状況を確認
+    print("\nFinal status:")
+    status = db.get_current_status()
+    for label, count in status.items():
+        print(f"  {label}: {count:,}")
+
+    db.close()
+    print("\nImport continuation completed!")
+
+except Exception as e:
+    print(f"Error: {e}")
+    sys.exit(1)

--- a/scripts/data_import/import_to_neo4j_test.py
+++ b/scripts/data_import/import_to_neo4j_test.py
@@ -1,0 +1,134 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+from neo4j import GraphDatabase
+
+
+# データ読み込み関数
+def load_json_ld(filename):
+    """JSON-LD形式のファイルを読み込む"""
+    with open(filename, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("@graph", [])
+
+
+# 1つのJSONファイルから限定的なデータを読み込む
+script_dir = Path(__file__).parent
+data_dir = script_dir.parent.parent / "data" / "mediaarts"
+json_files = list(data_dir.glob("*.json"))
+
+print(f"Looking for JSON files in: {data_dir}")
+print(f"Found {len(json_files)} JSON files")
+
+# 最初のファイルから最大1000件のみ読み込む
+all_data = []
+if json_files:
+    test_file = json_files[0]
+    print(f"\nLoading test data from {test_file.name}...")
+    data = load_json_ld(str(test_file))
+    all_data = data[:1000]  # 最大1000件に制限
+    print(f"Loaded {len(all_data)} items for testing")
+
+# データの分類
+manga_books = []
+magazines = []
+authors = set()
+publishers = set()
+
+for item in all_data:
+    item_type = item.get("@type", "")
+    genre = item.get("schema:genre", "")
+    
+    if item_type == "class:MangaBook" and genre == "マンガ単行本":
+        manga_books.append(item)
+        
+        creator = item.get("dcterms:creator", {})
+        if isinstance(creator, dict) and "@id" in creator:
+            authors.add(creator["@id"])
+        
+        publisher = item.get("schema:publisher", "")
+        if publisher:
+            if isinstance(publisher, list):
+                for pub in publisher:
+                    if isinstance(pub, str):
+                        publishers.add(pub)
+            elif isinstance(publisher, str):
+                publishers.add(publisher)
+
+print(f"\nTest data summary:")
+print(f"- Manga books: {len(manga_books)}")
+print(f"- Authors: {len(authors)}")
+print(f"- Publishers: {len(publishers)}")
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+print(f"\nConnecting to Neo4j at {neo4j_uri}...")
+
+class MangaGraphDB:
+    def __init__(self, uri, user, password):
+        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+
+    def close(self):
+        self.driver.close()
+
+    def test_connection(self):
+        """接続テスト"""
+        with self.driver.session() as session:
+            result = session.run("RETURN 1 AS num")
+            return result.single()["num"] == 1
+
+    def count_nodes(self):
+        """ノード数をカウント"""
+        with self.driver.session() as session:
+            counts = {}
+            for label in ["Work", "Author", "Publisher", "Magazine"]:
+                result = session.run(f"MATCH (n:{label}) RETURN count(n) AS count")
+                counts[label] = result.single()["count"]
+            return counts
+
+    def create_sample_publisher(self, name):
+        """サンプル出版社を作成"""
+        with self.driver.session() as session:
+            query = """
+            MERGE (p:Publisher {id: $publisher_id})
+            SET p.name = $name
+            """
+            session.run(query, {"publisher_id": name, "name": name})
+
+try:
+    db = MangaGraphDB(neo4j_uri, neo4j_user, neo4j_password)
+    
+    # 接続テスト
+    if db.test_connection():
+        print("Successfully connected to Neo4j!")
+    
+    # 現在のノード数を確認
+    print("\nCurrent node counts:")
+    counts = db.count_nodes()
+    for label, count in counts.items():
+        print(f"  {label}: {count}")
+    
+    # テストデータをインポート
+    if publishers:
+        print(f"\nImporting {len(publishers)} test publishers...")
+        for i, publisher in enumerate(list(publishers)[:10]):  # 最大10件
+            db.create_sample_publisher(publisher)
+            print(f"  Imported {i+1}/{min(10, len(publishers))} publishers")
+    
+    # インポート後のノード数を確認
+    print("\nNode counts after test import:")
+    counts = db.count_nodes()
+    for label, count in counts.items():
+        print(f"  {label}: {count}")
+    
+    db.close()
+    print("\nTest completed successfully!")
+    
+except Exception as e:
+    print(f"Error: {e}")
+    sys.exit(1)

--- a/scripts/data_import/import_to_neo4j_v2.py
+++ b/scripts/data_import/import_to_neo4j_v2.py
@@ -1,0 +1,353 @@
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+from neo4j import GraphDatabase
+
+
+# データ読み込み関数
+def load_json_ld(filename):
+    """JSON-LD形式のファイルを読み込む"""
+    with open(filename, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("@graph", [])
+
+
+# 全てのJSONファイルからデータを読み込む
+all_data = []
+
+# スクリプトの場所から相対パスを解決
+script_dir = Path(__file__).parent
+data_dir = script_dir.parent.parent / "data" / "mediaarts"
+json_files = list(data_dir.glob("*.json"))
+
+print(f"Looking for JSON files in: {data_dir}")
+print(f"Found {len(json_files)} JSON files")
+
+for file_path in json_files:
+    print(f"Loading {file_path.name}...")
+    try:
+        data = load_json_ld(str(file_path))
+        all_data.extend(data)
+        print(f"  Loaded {len(data)} items from {file_path.name}")
+    except Exception as e:
+        print(f"Error loading {file_path}: {e}")
+
+print(f"\nTotal items loaded: {len(all_data)}")
+
+# データの分類
+manga_books = []  # マンガ単行本
+manga_works = []  # マンガ作品（シリーズ）
+magazines = []  # 雑誌
+authors = set()  # 著者
+publishers = set()  # 出版社
+
+# データを分類
+for item in all_data:
+    item_type = item.get("@type", "")
+    genre = item.get("schema:genre", "")
+
+    if item_type == "class:MangaBook" and genre == "マンガ単行本":
+        manga_books.append(item)
+
+        # 著者情報を収集
+        creator = item.get("dcterms:creator", {})
+        if isinstance(creator, dict) and "@id" in creator:
+            authors.add(creator["@id"])
+
+        # 出版社情報を収集
+        publisher = item.get("schema:publisher", "")
+        if publisher:
+            if isinstance(publisher, list):
+                for pub in publisher:
+                    if isinstance(pub, str):
+                        publishers.add(pub)
+            elif isinstance(publisher, str):
+                publishers.add(publisher)
+
+    elif genre in ["マンガ雑誌", "雑誌", "雑誌全号まとめ"] or "Magazine" in item_type:
+        magazines.append(item)
+
+        # 出版社情報を収集
+        publisher = item.get("schema:publisher", "")
+        if publisher:
+            if isinstance(publisher, list):
+                for pub in publisher:
+                    if isinstance(pub, str):
+                        publishers.add(pub)
+            elif isinstance(publisher, str):
+                publishers.add(publisher)
+
+# マンガ作品（シリーズ）の抽出 - 単行本から作品名でグループ化
+work_dict = {}
+for book in manga_books:
+    # 作品名を取得（巻数を除いたタイトル）
+    full_name = book.get("schema:name", "")
+
+    # nameフィールドの処理 - リストや辞書の場合を考慮
+    if isinstance(full_name, list):
+        # リストの場合、最初の要素を取得（文字列のみ）
+        for name in full_name:
+            if isinstance(name, str):
+                full_name = name
+                break
+            elif isinstance(name, dict) and "@value" in name:
+                full_name = name["@value"]
+                break
+        else:
+            continue  # 有効な名前が見つからない場合はスキップ
+    elif isinstance(full_name, dict):
+        # 辞書の場合、@valueフィールドを確認
+        if "@value" in full_name:
+            full_name = full_name["@value"]
+        else:
+            continue  # 有効な名前が見つからない場合はスキップ
+    elif not isinstance(full_name, str):
+        continue  # 文字列でない場合はスキップ
+
+    # 巻数を除いた作品名を取得
+    work_name = full_name
+    volume_num = book.get("schema:volumeNumber", "")
+    if volume_num and isinstance(work_name, str):
+        # 巻数部分を削除
+        work_name = work_name.replace(f" {volume_num}", "").strip()
+
+    if work_name and isinstance(work_name, str):
+        if work_name not in work_dict:
+            work_dict[work_name] = {"name": work_name, "books": [], "creators": set(), "publishers": set()}
+
+        work_dict[work_name]["books"].append(book)
+
+        # 著者情報を追加
+        creator = book.get("dcterms:creator", {})
+        if isinstance(creator, dict) and "@id" in creator:
+            work_dict[work_name]["creators"].add(creator["@id"])
+
+        # 出版社情報を追加
+        publisher = book.get("schema:publisher", "")
+        if publisher:
+            if isinstance(publisher, list):
+                for pub in publisher:
+                    if isinstance(pub, str):
+                        work_dict[work_name]["publishers"].add(pub)
+            elif isinstance(publisher, str):
+                work_dict[work_name]["publishers"].add(publisher)
+
+print(f"Found {len(manga_books)} manga books")
+print(f"Found {len(work_dict)} manga works")
+print(f"Found {len(magazines)} magazines")
+print(f"Found {len(authors)} authors")
+print(f"Found {len(publishers)} publishers")
+
+
+class MangaGraphDB:
+    def __init__(self, uri, user, password):
+        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+
+    def close(self):
+        self.driver.close()
+
+    def create_constraints(self):
+        with self.driver.session() as session:
+            # ユニーク制約の作成
+            session.run("CREATE CONSTRAINT IF NOT EXISTS FOR (w:Work) REQUIRE w.id IS UNIQUE")
+            session.run("CREATE CONSTRAINT IF NOT EXISTS FOR (a:Author) REQUIRE a.id IS UNIQUE")
+            session.run("CREATE CONSTRAINT IF NOT EXISTS FOR (m:Magazine) REQUIRE m.id IS UNIQUE")
+            session.run("CREATE CONSTRAINT IF NOT EXISTS FOR (p:Publisher) REQUIRE p.id IS UNIQUE")
+
+    def create_work_node(self, work_name, work_data):
+        """マンガ作品（シリーズ）ノードを作成"""
+        with self.driver.session() as session:
+            query = """
+            MERGE (w:Work {id: $work_id})
+            SET w.title = $title,
+                w.total_volumes = $total_volumes,
+                w.first_published = $first_published,
+                w.last_published = $last_published
+            """
+
+            # 総巻数と最初・最後の出版日を計算
+            total_volumes = len(work_data["books"])
+            dates = [
+                book.get("schema:datePublished", "") for book in work_data["books"] if book.get("schema:datePublished")
+            ]
+            first_published = min(dates) if dates else ""
+            last_published = max(dates) if dates else ""
+
+            session.run(
+                query,
+                {
+                    "work_id": work_name,  # 作品名をIDとして使用
+                    "title": work_name,
+                    "total_volumes": total_volumes,
+                    "first_published": first_published,
+                    "last_published": last_published,
+                },
+            )
+
+    def create_author_node(self, author_id):
+        """著者ノードを作成（現時点ではIDのみ）"""
+        with self.driver.session() as session:
+            query = """
+            MERGE (a:Author {id: $author_id})
+            """
+            session.run(query, {"author_id": author_id})
+
+    def create_magazine_node(self, magazine):
+        """雑誌ノードを作成"""
+        with self.driver.session() as session:
+            query = """
+            MERGE (m:Magazine {id: $magazine_id})
+            SET m.title = $title,
+                m.publisher = $publisher,
+                m.genre = $genre
+            """
+
+            # タイトルの取得
+            title = magazine.get("schema:name", "")
+            if isinstance(title, list):
+                title = title[0] if title else ""
+
+            session.run(
+                query,
+                {
+                    "magazine_id": magazine.get("@id", ""),
+                    "title": title,
+                    "publisher": magazine.get("schema:publisher", ""),
+                    "genre": magazine.get("schema:genre", ""),
+                },
+            )
+
+    def create_publisher_node(self, publisher_name):
+        """出版社ノードを作成"""
+        with self.driver.session() as session:
+            query = """
+            MERGE (p:Publisher {id: $publisher_id})
+            SET p.name = $name
+            """
+            session.run(query, {"publisher_id": publisher_name, "name": publisher_name})
+
+    def create_work_author_relationship(self, work_name, author_id):
+        """作品と著者の関係を作成"""
+        with self.driver.session() as session:
+            query = """
+            MATCH (w:Work {id: $work_id})
+            MATCH (a:Author {id: $author_id})
+            MERGE (w)-[:CREATED_BY]->(a)
+            """
+            session.run(query, {"work_id": work_name, "author_id": author_id})
+
+    def create_work_magazine_relationship(self, work_name, magazine_id):
+        """作品と雑誌の関係を作成（TODO: 掲載情報が必要）"""
+        pass
+
+    def create_magazine_publisher_relationship(self, magazine_id, publisher_name):
+        """雑誌と出版社の関係を作成"""
+        with self.driver.session() as session:
+            query = """
+            MATCH (m:Magazine {id: $magazine_id})
+            MATCH (p:Publisher {id: $publisher_id})
+            MERGE (m)-[:PUBLISHED_BY]->(p)
+            """
+            session.run(query, {"magazine_id": magazine_id, "publisher_id": publisher_name})
+
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+print(f"\nConnecting to Neo4j at {neo4j_uri}...")
+
+try:
+    db = MangaGraphDB(neo4j_uri, neo4j_user, neo4j_password)
+except Exception as e:
+    print(f"Failed to connect to Neo4j: {e}")
+    print("Please check your Neo4j connection settings.")
+    print("You can set environment variables: NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD")
+    sys.exit(1)
+
+# 制約の作成
+try:
+    print("Creating constraints...")
+    db.create_constraints()
+except Exception as e:
+    print(f"Error creating constraints: {e}")
+
+# データのサマリーを表示
+print(f"\nData summary:")
+print(f"- Publishers: {len(publishers)}")
+print(f"- Authors: {len(authors)}")
+print(f"- Magazines: {len(magazines)}")
+print(f"- Works: {len(work_dict)}")
+
+# バッチ処理のサイズ
+BATCH_SIZE = 100
+
+# 1. 出版社ノードの作成
+print("\nCreating publisher nodes...")
+publisher_list = list(publishers)
+for i in range(0, len(publisher_list), BATCH_SIZE):
+    batch = publisher_list[i : i + BATCH_SIZE]
+    try:
+        for publisher in batch:
+            db.create_publisher_node(publisher)
+        print(f"  Processed {min(i + BATCH_SIZE, len(publisher_list))}/{len(publisher_list)} publishers")
+    except Exception as e:
+        print(f"  Error processing publishers batch {i//BATCH_SIZE + 1}: {e}")
+
+# 2. 著者ノードの作成
+print("\nCreating author nodes...")
+author_list = list(authors)
+for i in range(0, len(author_list), BATCH_SIZE):
+    batch = author_list[i : i + BATCH_SIZE]
+    try:
+        for author_id in batch:
+            db.create_author_node(author_id)
+        print(f"  Processed {min(i + BATCH_SIZE, len(author_list))}/{len(author_list)} authors")
+    except Exception as e:
+        print(f"  Error processing authors batch {i//BATCH_SIZE + 1}: {e}")
+
+# 3. 雑誌ノードの作成
+print("\nCreating magazine nodes...")
+for i in range(0, len(magazines), BATCH_SIZE):
+    batch = magazines[i : i + BATCH_SIZE]
+    try:
+        for magazine in batch:
+            db.create_magazine_node(magazine)
+
+            # 雑誌と出版社の関係を作成
+            publisher = magazine.get("schema:publisher", "")
+            if publisher:
+                if isinstance(publisher, list):
+                    publisher = publisher[0] if publisher else ""
+                if publisher:
+                    db.create_magazine_publisher_relationship(magazine.get("@id", ""), publisher)
+        print(f"  Processed {min(i + BATCH_SIZE, len(magazines))}/{len(magazines)} magazines")
+    except Exception as e:
+        print(f"  Error processing magazines batch {i//BATCH_SIZE + 1}: {e}")
+
+# 4. 作品ノードの作成と関係の構築
+print("\nCreating work nodes and relationships...")
+work_items = list(work_dict.items())
+for i in range(0, len(work_items), BATCH_SIZE):
+    batch = work_items[i : i + BATCH_SIZE]
+    try:
+        for work_name, work_data in batch:
+            # 作品ノードを作成
+            db.create_work_node(work_name, work_data)
+
+            # 作品と著者の関係を作成
+            for creator_id in work_data["creators"]:
+                db.create_work_author_relationship(work_name, creator_id)
+        print(f"  Processed {min(i + BATCH_SIZE, len(work_items))}/{len(work_items)} works")
+    except Exception as e:
+        print(f"  Error processing works batch {i//BATCH_SIZE + 1}: {e}")
+
+print("\nImport completed!")
+
+# 接続を閉じる
+db.close()

--- a/scripts/data_import/import_to_neo4j_v3.py
+++ b/scripts/data_import/import_to_neo4j_v3.py
@@ -1,0 +1,689 @@
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from kanjiconv import KanjiConv
+from neo4j import GraphDatabase
+import re
+
+
+# データ読み込み関数
+def load_json_ld(filename):
+    """JSON-LD形式のファイルを読み込む"""
+    with open(filename, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("@graph", [])
+
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+
+class NameNormalizer:
+    """名前の正規化と統一を行うクラス"""
+
+    def __init__(self):
+        self.kanjiconv = KanjiConv()
+        self.name_map = {}  # 正規化名 -> 表示名のマッピング
+        self.reverse_map = {}  # 入力名 -> 正規化名のマッピング
+
+    def normalize(self, name):
+        """名前を正規化（ひらがなに変換）"""
+        if not name or not isinstance(name, str):
+            return None
+        # カッコ内の内容を削除
+        name_without_paren = name.split("(")[0].split("（")[0].strip()
+        # ひらがなに変換
+        normalized = self.kanjiconv.to_hiragana(name_without_paren)
+        return normalized.lower()
+
+    def register_name(self, name):
+        """名前を登録して正規化IDを返す"""
+        if not name or not isinstance(name, str):
+            return None
+
+        normalized = self.normalize(name)
+        if not normalized:
+            return None
+
+        # 既に登録されている場合
+        if name in self.reverse_map:
+            return self.reverse_map[name]
+
+        # 正規化名が既に存在する場合
+        if normalized in self.name_map:
+            # 優先順位に基づいて表示名を更新
+            existing_name = self.name_map[normalized]
+            if self._should_update_display_name(existing_name, name):
+                self.name_map[normalized] = name
+        else:
+            # 新規登録
+            self.name_map[normalized] = name
+
+        self.reverse_map[name] = normalized
+        return normalized
+
+    def get_display_name(self, normalized_name):
+        """正規化名から表示名を取得"""
+        return self.name_map.get(normalized_name, normalized_name)
+
+    def _should_update_display_name(self, existing, new):
+        """表示名を更新すべきかどうかを判定"""
+
+        # 優先順位: 漢字 > ローマ字 > カタカナ > ひらがな
+        def get_priority(name):
+            if any("\u4e00" <= char <= "\u9fff" for char in name):  # 漢字
+                return 4
+            elif any("A" <= char <= "Z" or "a" <= char <= "z" for char in name):  # ローマ字
+                return 3
+            elif any("\u30a0" <= char <= "\u30ff" for char in name):  # カタカナ
+                return 2
+            else:  # ひらがな
+                return 1
+
+        return get_priority(new) > get_priority(existing)
+
+
+def extract_magazines_from_description(description):
+    """schema:descriptionフィールドから雑誌名を抽出する"""
+    if not description or not isinstance(description, str):
+        return []
+    
+    magazines = []
+    # 「初出：」で始まる部分を探す
+    if "初出：" in description:
+        # 初出：以降の部分を取得
+        initial_part = description.split("初出：", 1)[1]
+        
+        # 「」で囲まれた雑誌名を抽出
+        magazine_matches = re.findall(r'「([^」]+)」', initial_part)
+        
+        for magazine in magazine_matches:
+            # 雑誌名をクリーンアップ（余分な文字を除去）
+            clean_magazine = magazine.strip()
+            if clean_magazine and len(clean_magazine) > 1:  # 空でなく、1文字以上
+                magazines.append(clean_magazine)
+    
+    return magazines
+
+
+class MangaGraphDB:
+    def __init__(self, uri, user, password):
+        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+        self.author_normalizer = NameNormalizer()
+        self.publisher_normalizer = NameNormalizer()
+        self.magazine_normalizer = NameNormalizer()
+
+    def close(self):
+        self.driver.close()
+
+    def clear_database(self):
+        """データベースをクリア"""
+        with self.driver.session() as session:
+            session.run("MATCH (n) DETACH DELETE n")
+            print("Database cleared.")
+
+    def create_constraints(self):
+        """制約を作成"""
+        with self.driver.session() as session:
+            constraints = [
+                "CREATE CONSTRAINT IF NOT EXISTS FOR (w:Work) REQUIRE w.id IS UNIQUE",
+                "CREATE CONSTRAINT IF NOT EXISTS FOR (a:Author) REQUIRE a.id IS UNIQUE",
+                "CREATE CONSTRAINT IF NOT EXISTS FOR (m:Magazine) REQUIRE m.id IS UNIQUE",
+                "CREATE CONSTRAINT IF NOT EXISTS FOR (p:Publisher) REQUIRE p.id IS UNIQUE",
+            ]
+            for constraint in constraints:
+                session.run(constraint)
+
+    def get_current_status(self):
+        """現在のインポート状況を確認"""
+        with self.driver.session() as session:
+            status = {}
+            for label in ["Work", "Author", "Publisher", "Magazine"]:
+                result = session.run(f"MATCH (n:{label}) RETURN count(n) AS count")
+                status[label] = result.single()["count"]
+            return status
+
+    def create_work_node(self, work_name, work_data):
+        """マンガ作品（シリーズ）ノードを作成"""
+        # 最初の本から@idを取得
+        first_book = work_data["books"][0] if work_data["books"] else {}
+        work_id = first_book.get("@id", "")
+        
+        # @idがない場合は作品名から生成
+        if not work_id:
+            work_id = work_name.upper()
+
+        with self.driver.session() as session:
+            query = """
+            MERGE (w:Work {id: $work_id})
+            SET w.title = $title,
+                w.total_volumes = $total_volumes,
+                w.first_published = $first_published,
+                w.last_published = $last_published,
+                w.genre = $genre,
+                w.is_series = $is_series
+            """
+
+            # 総巻数と最初・最後の出版日を計算
+            total_volumes = len(work_data["books"])
+            dates = [
+                book.get("schema:datePublished", "") for book in work_data["books"] if book.get("schema:datePublished")
+            ]
+            first_published = min(dates) if dates else ""
+            last_published = max(dates) if dates else ""
+
+            # ジャンルを取得
+            genre = first_book.get("schema:genre", "")
+
+            # シリーズかどうか（複数巻あるか）
+            is_series = total_volumes > 1
+
+            session.run(
+                query,
+                {
+                    "work_id": work_id,
+                    "title": work_name,  # 表示名は元のまま
+                    "total_volumes": total_volumes,
+                    "first_published": first_published,
+                    "last_published": last_published,
+                    "genre": genre,
+                    "is_series": is_series,
+                },
+            )
+            
+        return work_id  # 作成したwork_idを返す
+
+    def create_author_node(self, author_id, author_name=None):
+        """著者ノードを作成"""
+        with self.driver.session() as session:
+            # author_nameが提供されている場合は正規化
+            if author_name:
+                normalized_id = self.author_normalizer.register_name(author_name)
+                if normalized_id:
+                    display_name = self.author_normalizer.get_display_name(normalized_id)
+                    query = """
+                    MERGE (a:Author {id: $author_id})
+                    SET a.name = $name,
+                        a.normalized_id = $normalized_id
+                    """
+                    session.run(
+                        query, {"author_id": normalized_id, "name": display_name, "normalized_id": normalized_id}
+                    )
+                    return normalized_id
+
+            # IDのみの場合
+            query = """
+            MERGE (a:Author {id: $author_id})
+            """
+            session.run(query, {"author_id": author_id})
+            return author_id
+
+    def create_publisher_node(self, publisher_name):
+        """出版社ノードを作成"""
+        normalized_id = self.publisher_normalizer.register_name(publisher_name)
+        if not normalized_id:
+            return None
+
+        display_name = self.publisher_normalizer.get_display_name(normalized_id)
+
+        with self.driver.session() as session:
+            query = """
+            MERGE (p:Publisher {id: $publisher_id})
+            SET p.name = $name
+            """
+            session.run(query, {"publisher_id": normalized_id, "name": display_name})
+
+        return normalized_id
+
+    def create_magazine_node(self, magazine):
+        """雑誌ノードを作成"""
+        # タイトルの取得
+        title = magazine.get("schema:name", "")
+        if isinstance(title, list):
+            title = title[0] if title else ""
+
+        if not title:
+            return None
+
+        normalized_id = self.magazine_normalizer.register_name(title)
+        if not normalized_id:
+            return None
+
+        display_name = self.magazine_normalizer.get_display_name(normalized_id)
+
+        with self.driver.session() as session:
+            query = """
+            MERGE (m:Magazine {id: $magazine_id})
+            SET m.title = $title,
+                m.genre = $genre,
+                m.original_id = $original_id
+            """
+
+            session.run(
+                query,
+                {
+                    "magazine_id": normalized_id,
+                    "title": display_name,
+                    "genre": magazine.get("schema:genre", ""),
+                    "original_id": magazine.get("@id", ""),
+                },
+            )
+
+        return normalized_id
+
+    def create_work_author_relationship(self, work_id, author_id):
+        """作品と著者の関係を作成"""
+        with self.driver.session() as session:
+            query = """
+            MATCH (w:Work {id: $work_id})
+            MATCH (a:Author {id: $author_id})
+            MERGE (w)-[:CREATED_BY]->(a)
+            """
+            session.run(query, {"work_id": work_id, "author_id": author_id})
+
+    def create_work_magazine_relationship(self, work_id, magazine_id):
+        """作品と雑誌の関係を作成"""
+        with self.driver.session() as session:
+            query = """
+            MATCH (w:Work {id: $work_id})
+            MATCH (m:Magazine {id: $magazine_id})
+            MERGE (w)-[:PUBLISHED_IN]->(m)
+            """
+            session.run(query, {"work_id": work_id, "magazine_id": magazine_id})
+
+    def create_magazine_publisher_relationship(self, magazine_id, publisher_id):
+        """雑誌と出版社の関係を作成"""
+        with self.driver.session() as session:
+            query = """
+            MATCH (m:Magazine {id: $magazine_id})
+            MATCH (p:Publisher {id: $publisher_id})
+            MERGE (m)-[:PUBLISHED_BY]->(p)
+            """
+            session.run(query, {"magazine_id": magazine_id, "publisher_id": publisher_id})
+
+
+# メイン処理
+print("=== Neo4j Import v3 ===")
+
+# データベースクリアの確認
+clear_db = input("\nClear database before import? (y/N): ").strip().lower()
+
+try:
+    db = MangaGraphDB(neo4j_uri, neo4j_user, neo4j_password)
+
+    if clear_db == "y":
+        db.clear_database()
+
+    # 制約を作成
+    print("\nCreating constraints...")
+    db.create_constraints()
+
+    # 現在の状況を確認
+    print("\nCurrent status:")
+    status = db.get_current_status()
+    for label, count in status.items():
+        print(f"  {label}: {count:,}")
+
+    # データを読み込む
+    print("\nLoading data...")
+    script_dir = Path(__file__).parent
+    data_dir = script_dir.parent.parent / "data" / "mediaarts"
+    json_files = list(data_dir.glob("*.json"))
+
+    all_data = []
+    for file_path in json_files:
+        print(f"Loading {file_path.name}...")
+        try:
+            data = load_json_ld(str(file_path))
+            all_data.extend(data)
+        except Exception as e:
+            print(f"Error loading {file_path}: {e}")
+
+    print(f"\nTotal items loaded: {len(all_data)}")
+
+    # データの分類
+    manga_books = []
+    magazines = []
+    authors_data = {}  # author_id -> author_data
+    publishers = set()
+
+    print("\nClassifying data...")
+    error_count = 0
+
+    for i, item in enumerate(all_data):
+        if i % 10000 == 0:
+            print(f"  Progress: {i}/{len(all_data)}")
+
+        try:
+            item_type = item.get("@type", "")
+            genre = item.get("schema:genre", "")
+
+            if item_type == "class:MangaBook" and genre == "マンガ単行本":
+                manga_books.append(item)
+
+                # 著者情報を収集
+                creator = item.get("dcterms:creator", {})
+                if isinstance(creator, dict) and "@id" in creator:
+                    author_id = creator["@id"]
+                    if author_id not in authors_data:
+                        authors_data[author_id] = {"id": author_id, "names": set()}
+
+                    # 著者名を収集（schema:creatorから）
+                    creator_names = item.get("schema:creator", [])
+                    if isinstance(creator_names, str):
+                        creator_names = [creator_names]
+                    elif not isinstance(creator_names, list):
+                        creator_names = []
+
+                    for name in creator_names:
+                        if isinstance(name, str) and name:
+                            authors_data[author_id]["names"].add(name)
+                        elif isinstance(name, dict):
+                            name_value = name.get("@value", name.get("name", ""))
+                            if name_value and isinstance(name_value, str):
+                                authors_data[author_id]["names"].add(name_value)
+
+                # 出版社情報を収集
+                publisher = item.get("schema:publisher", "")
+                if publisher:
+                    if isinstance(publisher, list):
+                        for pub in publisher:
+                            if isinstance(pub, str):
+                                publishers.add(pub)
+                            elif isinstance(pub, dict):
+                                # 辞書の場合、@valueや他のフィールドを確認
+                                pub_name = pub.get("@value", pub.get("name", ""))
+                                if pub_name and isinstance(pub_name, str):
+                                    publishers.add(pub_name)
+                    elif isinstance(publisher, str):
+                        publishers.add(publisher)
+                    elif isinstance(publisher, dict):
+                        # 辞書の場合、@valueや他のフィールドを確認
+                        pub_name = publisher.get("@value", publisher.get("name", ""))
+                        if pub_name and isinstance(pub_name, str):
+                            publishers.add(pub_name)
+
+            elif genre in ["マンガ雑誌", "雑誌", "雑誌全号まとめ"] or "Magazine" in item_type:
+                magazines.append(item)
+
+                # 出版社情報を収集
+                publisher = item.get("schema:publisher", "")
+                if publisher:
+                    if isinstance(publisher, list):
+                        for pub in publisher:
+                            if isinstance(pub, str):
+                                publishers.add(pub)
+                            elif isinstance(pub, dict):
+                                # 辞書の場合、@valueや他のフィールドを確認
+                                pub_name = pub.get("@value", pub.get("name", ""))
+                                if pub_name and isinstance(pub_name, str):
+                                    publishers.add(pub_name)
+                    elif isinstance(publisher, str):
+                        publishers.add(publisher)
+                    elif isinstance(publisher, dict):
+                        # 辞書の場合、@valueや他のフィールドを確認
+                        pub_name = publisher.get("@value", publisher.get("name", ""))
+                        if pub_name and isinstance(pub_name, str):
+                            publishers.add(pub_name)
+        except Exception as e:
+            error_count += 1
+            if error_count <= 10:
+                print(f"  Error processing item {i}: {e}")
+                print(f"    Item type: {item.get('@type', 'Unknown')}")
+                print(f"    Genre: {item.get('schema:genre', 'Unknown')}")
+
+    print(f"\nClassification completed. Errors: {error_count}")
+
+    # マンガ作品（シリーズ）の抽出 - 単行本から作品名でグループ化
+    work_dict = {}
+    work_magazine_map = defaultdict(set)  # work -> set of magazines
+
+    print("\nGrouping manga books into works...")
+
+    for book in manga_books:
+        # 作品名を取得（巻数を除いたタイトル）
+        full_name = book.get("schema:name", "")
+
+        # nameフィールドの処理
+        if isinstance(full_name, list):
+            for name in full_name:
+                if isinstance(name, str):
+                    full_name = name
+                    break
+                elif isinstance(name, dict) and "@value" in name:
+                    full_name = name["@value"]
+                    break
+            else:
+                continue
+        elif isinstance(full_name, dict):
+            if "@value" in full_name:
+                full_name = full_name["@value"]
+            else:
+                continue
+        elif not isinstance(full_name, str):
+            continue
+
+        # 巻数を除いた作品名を取得
+        work_name = full_name
+        volume_num = book.get("schema:volumeNumber", "")
+        if volume_num and isinstance(work_name, str):
+            work_name = work_name.replace(f" {volume_num}", "").strip()
+
+        if work_name and isinstance(work_name, str):
+            # 作品名を大文字に統一してキーとする
+            work_key = work_name.upper()
+
+            if work_key not in work_dict:
+                work_dict[work_key] = {
+                    "name": work_name,  # 最初に見つかった表記を保持
+                    "books": [],
+                    "creators": set(),
+                    "publishers": set(),
+                }
+
+            work_dict[work_key]["books"].append(book)
+
+            # 著者情報を追加
+            creator = book.get("dcterms:creator", {})
+            if isinstance(creator, dict) and "@id" in creator:
+                creator_id = creator["@id"]
+                if isinstance(creator_id, str):
+                    work_dict[work_key]["creators"].add(creator_id)
+
+            # 出版社情報を追加
+            publisher = book.get("schema:publisher", "")
+            if publisher:
+                if isinstance(publisher, list):
+                    for pub in publisher:
+                        if isinstance(pub, str):
+                            work_dict[work_key]["publishers"].add(pub)
+                        elif isinstance(pub, dict):
+                            pub_name = pub.get("@value", pub.get("name", ""))
+                            if pub_name and isinstance(pub_name, str):
+                                work_dict[work_key]["publishers"].add(pub_name)
+                elif isinstance(publisher, str):
+                    work_dict[work_key]["publishers"].add(publisher)
+                elif isinstance(publisher, dict):
+                    pub_name = publisher.get("@value", publisher.get("name", ""))
+                    if pub_name and isinstance(pub_name, str):
+                        work_dict[work_key]["publishers"].add(pub_name)
+
+            # 掲載雑誌情報を収集（schema:descriptionから初出情報を抽出）
+            description = book.get("schema:description", "")
+            if description:
+                extracted_magazines = extract_magazines_from_description(description)
+                for magazine_name in extracted_magazines:
+                    work_magazine_map[work_key].add(magazine_name)
+
+    print(f"\nFound {len(manga_books)} manga books")
+    print(f"Found {len(work_dict)} unique works")
+    print(f"Found {len(magazines)} magazines")
+    print(f"Found {len(authors_data)} authors")
+    print(f"Found {len(publishers)} publishers")
+    
+    # デバッグ情報を追加
+    total_magazine_relations = sum(len(mags) for mags in work_magazine_map.values())
+    print(f"Found {total_magazine_relations} work-magazine relationships")
+    print(f"Found {len(work_magazine_map)} works with magazine info")
+
+    # バッチ処理のサイズ
+    BATCH_SIZE = 100
+
+    # 1. 出版社ノードの作成
+    print("\nCreating publisher nodes...")
+    publisher_map = {}  # original -> normalized_id
+
+    for i, publisher in enumerate(publishers):
+        if i % 100 == 0:
+            print(f"  Progress: {i}/{len(publishers)}")
+
+        publisher_id = db.create_publisher_node(publisher)
+        if publisher_id:
+            publisher_map[publisher] = publisher_id
+
+    # 2. 著者ノードの作成
+    print("\nCreating author nodes...")
+    author_map = {}  # original_id -> normalized_id
+
+    for i, (author_id, author_data) in enumerate(authors_data.items()):
+        if i % 100 == 0:
+            print(f"  Progress: {i}/{len(authors_data)}")
+
+        # 最も優先度の高い名前を選択
+        if author_data["names"]:
+            # 名前のリストから最も優先度の高いものを選択
+            best_name = None
+            best_priority = 0
+
+            for name in author_data["names"]:
+                priority = 0
+                if any("\u4e00" <= char <= "\u9fff" for char in name):  # 漢字
+                    priority = 4
+                elif any("A" <= char <= "Z" or "a" <= char <= "z" for char in name):  # ローマ字
+                    priority = 3
+                elif any("\u30a0" <= char <= "\u30ff" for char in name):  # カタカナ
+                    priority = 2
+                else:  # ひらがな
+                    priority = 1
+
+                if priority > best_priority:
+                    best_priority = priority
+                    best_name = name
+
+            normalized_id = db.create_author_node(author_id, best_name)
+        else:
+            normalized_id = db.create_author_node(author_id)
+
+        author_map[author_id] = normalized_id
+
+    # 3. 雑誌ノードの作成
+    print("\nCreating magazine nodes...")
+    magazine_map = {}  # magazine_name -> magazine_id
+    magazine_id_to_name = {}  # magazine_id -> magazine_name
+
+    for i, magazine in enumerate(magazines):
+        if i % 100 == 0:
+            print(f"  Progress: {i}/{len(magazines)}")
+
+        normalized_id = db.create_magazine_node(magazine)
+        if normalized_id:
+            # タイトルの取得
+            title = magazine.get("schema:name", "")
+            if isinstance(title, list):
+                title = title[0] if title else ""
+            
+            # 雑誌名をキーとして保存
+            if title:
+                magazine_map[title] = normalized_id
+                magazine_id_to_name[normalized_id] = title
+
+            # 雑誌と出版社の関係を作成
+            publisher = magazine.get("schema:publisher", "")
+            if publisher:
+                if isinstance(publisher, list):
+                    # リストの最初の要素を取得
+                    for pub in publisher:
+                        if isinstance(pub, str):
+                            publisher = pub
+                            break
+                        elif isinstance(pub, dict):
+                            pub_name = pub.get("@value", pub.get("name", ""))
+                            if pub_name and isinstance(pub_name, str):
+                                publisher = pub_name
+                                break
+                    else:
+                        publisher = ""
+                elif isinstance(publisher, dict):
+                    publisher = publisher.get("@value", publisher.get("name", ""))
+
+                if publisher and publisher in publisher_map:
+                    db.create_magazine_publisher_relationship(normalized_id, publisher_map[publisher])
+
+    # 4. 作品ノードの作成と関係の構築
+    print("\nCreating work nodes and relationships...")
+    work_items = list(work_dict.items())
+    
+    # デバッグ: 雑誌マップのサンプルを表示
+    print("\nMagazine map sample (first 10):")
+    for i, (name, mag_id) in enumerate(list(magazine_map.items())[:10]):
+        print(f"  {name} -> {mag_id}")
+
+    for i in range(0, len(work_items), BATCH_SIZE):
+        batch = work_items[i : i + BATCH_SIZE]
+        try:
+            for work_key, work_data in batch:
+                # 作品ノードを作成
+                work_id = db.create_work_node(work_data["name"], work_data)
+                
+                # work_idがNoneの場合はスキップ
+                if not work_id:
+                    print(f"  Warning: Failed to create work node for {work_data['name']}")
+                    continue
+
+                # 作品と著者の関係を作成
+                for creator_id in work_data["creators"]:
+                    if creator_id in author_map:
+                        db.create_work_author_relationship(work_id, author_map[creator_id])
+
+                # 作品と雑誌の関係を作成（雑誌名から検索）
+                magazine_names = work_magazine_map.get(work_key, [])
+                if magazine_names and i == 0 and work_key == work_items[0][0]:  # 最初の作品のみデバッグ
+                    print(f"\nDebug - First work magazine mapping:")
+                    print(f"  Work: {work_data['name']}")
+                    print(f"  Magazines from work: {magazine_names}")
+                    print(f"  Magazines found in map: {[m for m in magazine_names if m in magazine_map]}")
+                
+                for magazine_name in magazine_names:
+                    # 雑誌名で直接検索
+                    if magazine_name in magazine_map:
+                        db.create_work_magazine_relationship(work_id, magazine_map[magazine_name])
+
+            print(f"Processed {min(i + BATCH_SIZE, len(work_items))}/{len(work_items)} works")
+        except Exception as e:
+            print(f"Error processing works batch {i // BATCH_SIZE + 1}: {e}")
+
+    # 最終状況を確認
+    print("\nFinal status:")
+    status = db.get_current_status()
+    for label, count in status.items():
+        print(f"  {label}: {count:,}")
+
+    # リレーションシップのカウント
+    print("\nRelationship counts:")
+    with db.driver.session() as session:
+        for rel_type in ["CREATED_BY", "PUBLISHED_IN", "PUBLISHED_BY"]:
+            result = session.run(f"MATCH ()-[r:{rel_type}]->() RETURN count(r) AS count")
+            count = result.single()["count"]
+            print(f"  {rel_type}: {count:,}")
+
+    db.close()
+    print("\nImport completed!")
+
+except Exception as e:
+    print(f"Error: {e}")
+    sys.exit(1)

--- a/test_api_search.py
+++ b/test_api_search.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+API検索のテスト
+"""
+
+import requests
+import json
+
+# APIエンドポイント
+base_url = "http://127.0.0.1:8000"
+
+def test_neo4j_search():
+    """Neo4j検索エンドポイントのテスト"""
+    print("=== Testing Neo4j Search API ===")
+    
+    # 1. ONE PIECEで検索
+    print("\n1. Searching for 'ONE PIECE':")
+    response = requests.get(
+        f"{base_url}/api/v1/neo4j/search",
+        params={"q": "ONE PIECE", "limit": 20, "include_related": True}
+    )
+    print(f"Status: {response.status_code}")
+    data = response.json()
+    print(f"Response: {json.dumps(data, indent=2, ensure_ascii=False)}")
+    
+    # 2. ワンピースで検索
+    print("\n2. Searching for 'ワンピース':")
+    response = requests.get(
+        f"{base_url}/api/v1/neo4j/search",
+        params={"q": "ワンピース", "limit": 20, "include_related": True}
+    )
+    print(f"Status: {response.status_code}")
+    data = response.json()
+    print(f"Response: {json.dumps(data, indent=2, ensure_ascii=False)}")
+    
+    # 3. NARUTO検索
+    print("\n3. Searching for 'NARUTO':")
+    response = requests.get(
+        f"{base_url}/api/v1/neo4j/search",
+        params={"q": "NARUTO", "limit": 5, "include_related": False}
+    )
+    print(f"Status: {response.status_code}")
+    data = response.json()
+    print(f"Response: {json.dumps(data, indent=2, ensure_ascii=False)}")
+
+def test_media_arts_search():
+    """Media Arts検索エンドポイントのテスト（比較用）"""
+    print("\n=== Testing Media Arts Search API ===")
+    
+    print("\nSearching for 'ONE PIECE' in Media Arts:")
+    response = requests.get(
+        f"{base_url}/api/v1/media-arts/search",
+        params={"q": "ONE PIECE", "limit": 5}
+    )
+    print(f"Status: {response.status_code}")
+    data = response.json()
+    print(f"Found {data['total_nodes']} nodes and {data['total_edges']} edges")
+    
+    # 最初の数ノードを表示
+    if data['nodes']:
+        print("\nFirst few nodes:")
+        for node in data['nodes'][:3]:
+            print(f"  - {node['type']}: {node['label']}")
+
+if __name__ == "__main__":
+    test_neo4j_search()
+    test_media_arts_search()

--- a/test_magazine_extraction.py
+++ b/test_magazine_extraction.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+雑誌抽出関数のテスト
+"""
+import re
+import json
+
+def extract_magazines_from_description(description):
+    """schema:descriptionフィールドから雑誌名を抽出する"""
+    if not description or not isinstance(description, str):
+        return []
+    
+    magazines = []
+    # 「初出：」で始まる部分を探す
+    if "初出：" in description:
+        # 初出：以降の部分を取得
+        initial_part = description.split("初出：", 1)[1]
+        
+        # 「」で囲まれた雑誌名を抽出
+        magazine_matches = re.findall(r'「([^」]+)」', initial_part)
+        
+        for magazine in magazine_matches:
+            # 雑誌名をクリーンアップ（余分な文字を除去）
+            clean_magazine = magazine.strip()
+            if clean_magazine and len(clean_magazine) > 1:  # 空でなく、1文字以上
+                magazines.append(clean_magazine)
+    
+    return magazines
+
+# テストケース
+test_descriptions = [
+    "初出：「週刊ヤングジャンプ増刊 漫革」「週刊ヤングジャンプ」「コミックマーブル」",
+    "初出：「小学五年生」「小学六年生」",
+    "初出：「ゲッサン」200906～12",
+    "その他の情報",
+    "",
+    None
+]
+
+print("=== 雑誌抽出テスト ===")
+for i, desc in enumerate(test_descriptions):
+    magazines = extract_magazines_from_description(desc)
+    print(f"テスト {i+1}: {desc}")
+    print(f"抽出結果: {magazines}")
+    print("---")
+
+# 実際のデータをテスト
+print("\n=== 実際のデータをテスト ===")
+try:
+    with open("/Users/yamadahikaru/project/manga-graph/data/mediaarts/metadata104.json", "r", encoding="utf-8") as f:
+        data = json.load(f)
+    
+    count = 0
+    magazine_count = 0
+    
+    for item in data.get("@graph", [])[:100]:  # 最初の100件をテスト
+        item_type = item.get("@type", "")
+        genre = item.get("schema:genre", "")
+        if ("MangaBook" in item_type and "マンガ単行本" in genre) or item_type == "class:MangaBookSeries":
+            count += 1
+            description = item.get("schema:description", "")
+            magazines = extract_magazines_from_description(description)
+            
+            if magazines:
+                magazine_count += 1
+                print(f"作品: {item.get('schema:name', ['不明'])[0] if isinstance(item.get('schema:name'), list) else item.get('schema:name', '不明')}")
+                print(f"抽出雑誌: {magazines}")
+                print("---")
+    
+    print(f"\n処理した作品数: {count}")
+    print(f"雑誌情報があった作品数: {magazine_count}")
+    print(f"雑誌情報の割合: {magazine_count/count*100:.1f}%" if count > 0 else "0%")
+    
+except Exception as e:
+    print(f"エラー: {e}")

--- a/test_small_import.py
+++ b/test_small_import.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+小規模なデータセットでのインポートテスト
+"""
+import json
+import os
+import sys
+import re
+from collections import defaultdict
+from pathlib import Path
+
+from kanjiconv import KanjiConv
+from neo4j import GraphDatabase
+
+# NameNormalizerクラスをコピー
+class NameNormalizer:
+    """名前の正規化と統一を行うクラス"""
+
+    def __init__(self):
+        self.kanjiconv = KanjiConv()
+        self.name_map = {}  # 正規化名 -> 表示名のマッピング
+        self.reverse_map = {}  # 入力名 -> 正規化名のマッピング
+
+    def normalize(self, name):
+        """名前を正規化（ひらがなに変換）"""
+        if not name or not isinstance(name, str):
+            return None
+        # カッコ内の内容を削除
+        name_without_paren = name.split("(")[0].split("（")[0].strip()
+        # ひらがなに変換
+        normalized = self.kanjiconv.to_hiragana(name_without_paren)
+        return normalized.lower()
+
+    def register_name(self, name):
+        """名前を登録して正規化IDを返す"""
+        if not name or not isinstance(name, str):
+            return None
+
+        normalized = self.normalize(name)
+        if not normalized:
+            return None
+
+        # 既に登録されている場合
+        if name in self.reverse_map:
+            return self.reverse_map[name]
+
+        # 正規化名が既に存在する場合
+        if normalized in self.name_map:
+            # 優先順位に基づいて表示名を更新
+            existing_name = self.name_map[normalized]
+            if self._should_update_display_name(existing_name, name):
+                self.name_map[normalized] = name
+        else:
+            # 新規登録
+            self.name_map[normalized] = name
+
+        self.reverse_map[name] = normalized
+        return normalized
+
+    def get_display_name(self, normalized_name):
+        """正規化名から表示名を取得"""
+        return self.name_map.get(normalized_name, normalized_name)
+
+    def _should_update_display_name(self, existing, new):
+        """表示名を更新すべきかどうかを判定"""
+
+        # 優先順位: 漢字 > ローマ字 > カタカナ > ひらがな
+        def get_priority(name):
+            if any("\\u4e00" <= char <= "\\u9fff" for char in name):  # 漢字
+                return 4
+            elif any("A" <= char <= "Z" or "a" <= char <= "z" for char in name):  # ローマ字
+                return 3
+            elif any("\\u30a0" <= char <= "\\u30ff" for char in name):  # カタカナ
+                return 2
+            else:  # ひらがな
+                return 1
+
+        return get_priority(new) > get_priority(existing)
+
+
+def extract_magazines_from_description(description):
+    """schema:descriptionフィールドから雑誌名を抽出する"""
+    if not description or not isinstance(description, str):
+        return []
+    
+    magazines = []
+    # 「初出：」で始まる部分を探す
+    if "初出：" in description:
+        # 初出：以降の部分を取得
+        initial_part = description.split("初出：", 1)[1]
+        
+        # 「」で囲まれた雑誌名を抽出
+        magazine_matches = re.findall(r'「([^」]+)」', initial_part)
+        
+        for magazine in magazine_matches:
+            # 雑誌名をクリーンアップ（余分な文字を除去）
+            clean_magazine = magazine.strip()
+            if clean_magazine and len(clean_magazine) > 1:  # 空でなく、1文字以上
+                magazines.append(clean_magazine)
+    
+    return magazines
+
+
+def load_json_ld(filename):
+    """JSON-LD形式のファイルを読み込む"""
+    with open(filename, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("@graph", [])
+
+
+# Neo4j接続設定
+neo4j_uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+neo4j_user = os.getenv("NEO4J_USER", "neo4j")
+neo4j_password = os.getenv("NEO4J_PASSWORD", "password")
+
+try:
+    driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
+    
+    # 小規模テスト用に最初の1000件のみ処理
+    print("=== 小規模インポートテスト ===")
+    
+    data_dir = Path("/Users/yamadahikaru/project/manga-graph/data/mediaarts")
+    data_file = data_dir / "metadata104.json"
+    
+    print(f"Loading {data_file.name}...")
+    all_data = load_json_ld(str(data_file))
+    
+    # 最初の1000件のみ
+    test_data = all_data[:1000]
+    print(f"Test data items: {len(test_data)}")
+    
+    # 作品と雑誌情報を収集
+    work_magazine_map = defaultdict(set)
+    manga_books = []
+    magazines = set()
+    
+    print("\\nClassifying data...")
+    
+    for item in test_data:
+        item_type = item.get("@type", "")
+        genre = item.get("schema:genre", "")
+
+        if ("MangaBook" in item_type and "マンガ単行本" in genre) or item_type == "class:MangaBookSeries":
+            manga_books.append(item)
+            
+            # 作品名を取得
+            full_name = item.get("schema:name", "")
+            if isinstance(full_name, list):
+                full_name = full_name[0] if full_name else ""
+            elif isinstance(full_name, dict):
+                full_name = full_name.get("@value", "")
+            
+            if full_name and isinstance(full_name, str):
+                work_key = full_name.upper()
+                
+                # 雑誌情報を収集（schema:descriptionから初出情報を抽出）
+                description = item.get("schema:description", "")
+                if description:
+                    extracted_magazines = extract_magazines_from_description(description)
+                    for magazine_name in extracted_magazines:
+                        work_magazine_map[work_key].add(magazine_name)
+                        magazines.add(magazine_name)
+                        print(f"Found magazine connection: {full_name} -> {magazine_name}")
+
+    print(f"\\nFound {len(manga_books)} manga books")
+    print(f"Found {len(magazines)} unique magazines from descriptions")
+    print(f"Work-magazine connections: {sum(len(v) for v in work_magazine_map.values())}")
+    
+    # 雑誌詳細を表示
+    print("\\n=== 発見した雑誌 ===")
+    for magazine in sorted(magazines):
+        print(f"- {magazine}")
+    
+    print("\\n=== 作品-雑誌の関係 ===")
+    for work_key, magazine_set in work_magazine_map.items():
+        if magazine_set:
+            print(f"{work_key}: {list(magazine_set)}")
+    
+    driver.close()
+    
+except Exception as e:
+    print(f"Error: {e}")
+    import traceback
+    traceback.print_exc()


### PR DESCRIPTION
- Implemented `import_to_neo4j_v3.py` for importing manga data into Neo4j, including normalization of names and relationships between works, authors, magazines, and publishers.
- Created `test_api_search.py` to test Neo4j search API endpoints with various queries.
- Developed `test_magazine_extraction.py` to validate the extraction of magazine names from descriptions.
- Added `test_small_import.py` for testing the import functionality with a small dataset, ensuring correct classification and relationships.